### PR TITLE
Make plugin registration transactional

### DIFF
--- a/.vllm-hust/optimization.json
+++ b/.vllm-hust/optimization.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "latchmoe",
+  "repository": "vllm-ascend-hust-LatchMoE",
+  "source_subdir": "",
+  "entrypoint": {"group": "vllm.platform_plugins", "name": "moe_offload_ascend"},
+  "parameters": {
+    "offload_gb": {"flag": "--offload-gb", "default": "14"}
+  },
+  "activation": {
+    "vllm_plugins": ["ascend", "moe_offload_ascend"],
+    "environment": {
+      "VLLM_ASCEND_MOE_OFFLOAD_GB": "${offload_gb}",
+      "VLLM_ASCEND_MOE_OFFLOAD_SEW_DATAPLANE": "1",
+      "VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT": "1",
+      "VLLM_ENGINE_MAX_NUM_SEQS": "1"
+    },
+    "extra_env_prefixes": ["VLLM_ASCEND_MOE_OFFLOAD_"]
+  },
+  "compatibility": {"incompatible_with": ["diffspec"]}
+}

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ PY
 
 ## Quick Start
 
+With sibling `vllm-hust-dev-hub`, the repository manifest handles installation,
+entry-point validation, safe defaults, and environment injection:
+
+```bash
+cd ../vllm-hust-dev-hub
+./manage.sh restart --optimization latchmoe --offload-gb 14
+```
+
+The equivalent low-level invocation is documented below for standalone use.
+
 ```bash
 # Offload budget in GiB; setting this enables the plugin via AutoConfig
 export VLLM_ASCEND_MOE_OFFLOAD_GB=14

--- a/tests/test_benchmark_design.py
+++ b/tests/test_benchmark_design.py
@@ -40,9 +40,10 @@ def load_collect_evidence():
 
 
 
-def test_benchmark_config_validates():
+def test_benchmark_config_validates(monkeypatch):
     sew_bench = load_sew_bench()
     config = sew_bench.load_config()
+    monkeypatch.setattr(Path, "exists", lambda _path: True)
 
     assert sew_bench.validate_config(config) == []
     assert config["dataset"]["source"] == "sharegpt"
@@ -241,5 +242,4 @@ def test_collect_evidence_extracts_log_and_profile_fields(tmp_path):
     assert row["slot_bank_gib"] == 2.0
     assert row["h2d_gib_total"] == 2048 / collect.BYTES_PER_GIB
     assert row["stage_ms_total"] == 3.0
-
 

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,26 @@ def test_platform_plugin_entry_point_is_declared() -> None:
     assert (
         'moe_offload_ascend = "vllm_moe_offload_ascend:register"' in config
     )
+
+
+def test_vllm_hust_optimization_manifest_matches_entry_point() -> None:
+    manifest = json.loads(
+        (REPO_ROOT / ".vllm-hust" / "optimization.json").read_text()
+    )
+
+    assert manifest["schema_version"] == 1
+    assert manifest["id"] == "latchmoe"
+    assert manifest["entrypoint"] == {
+        "group": "vllm.platform_plugins",
+        "name": "moe_offload_ascend",
+    }
+    assert manifest["parameters"]["offload_gb"]["default"] == "14"
+    assert manifest["activation"]["vllm_plugins"] == [
+        "ascend",
+        "moe_offload_ascend",
+    ]
+    environment = manifest["activation"]["environment"]
+    assert environment["VLLM_ASCEND_MOE_OFFLOAD_GB"] == "${offload_gb}"
 
 
 def test_register_applies_patches_once(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import vllm_moe_offload_ascend as plugin
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin, "_REGISTERED", False)
+
+
+def test_platform_plugin_entry_point_is_declared() -> None:
+    config = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert '[project.entry-points."vllm.platform_plugins"]' in config
+    assert (
+        'moe_offload_ascend = "vllm_moe_offload_ascend:register"' in config
+    )
+
+
+def test_register_applies_patches_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "vllm_moe_offload_ascend.patches.patch_fused_moe.apply_patches",
+        lambda: calls.append("patched"),
+    )
+
+    plugin.register()
+    plugin.register()
+
+    assert calls == ["patched"]
+    assert plugin._REGISTERED is True
+
+
+def test_failed_registration_can_be_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail() -> None:
+        raise RuntimeError("missing vllm-ascend hook")
+
+    monkeypatch.setattr(
+        "vllm_moe_offload_ascend.patches.patch_fused_moe.apply_patches",
+        fail,
+    )
+
+    with pytest.raises(RuntimeError, match="missing vllm-ascend hook"):
+        plugin.register()
+
+    assert plugin._REGISTERED is False

--- a/vllm_moe_offload_ascend/__init__.py
+++ b/vllm_moe_offload_ascend/__init__.py
@@ -20,8 +20,16 @@ monkey-patches the hook points in vllm_ascend so the real MoE offload
 logic is active instead of the null stubs.
 """
 
+_REGISTERED = False
+
 
 def register() -> None:
     """Entry point called by vllm's platform plugin system at startup."""
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
     from vllm_moe_offload_ascend.patches.patch_fused_moe import apply_patches
+
     apply_patches()
+    _REGISTERED = True


### PR DESCRIPTION
Superseded by #3, which carries the same lifecycle fix on a policy-compliant
`feature/...` branch together with the repository branch policy. The focused
contract suite passes there; runtime and NPU validation remain tracked as
separate issue-level gates.
