### PR TITLE
Define LatchMoE as a separate runtime project

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,23 @@
 
 > 📄 **Paper**: in preparation
 
+- 负责人：李昶吾（`@Li-changwu`）、陈德斌（`@pluviophile-chen`）
+- 当前工作：[运行时边界与 graph 路径证据 #4](https://github.com/vLLM-HUST/vllm-ascend-hust-LatchMoE/issues/4)
+
 ---
+
+## Project Boundary
+
+LatchMoE is the runtime-mechanism project. It owns the address-stable slot
+bank, Host Store and H2D path, graph-replay lifecycle, wave prefill, and a
+generic placement-plan adapter. Policy research such as Static, frequency,
+route-transition, EPLB matched comparisons, and experiment orchestration is
+owned by the separate
+[`intellistream/ascend-moe-control`](https://github.com/intellistream/ascend-moe-control)
+project. New control policies must not be added to LatchMoE's main branch.
+
+Graph-path failures must be diagnosed directly. Forced eager execution is not
+an acceptable substitute for graph validation.
 
 ## What LatchMoE Does
 


### PR DESCRIPTION
## 改动

- 在 README 标明共同负责人李昶吾、陈德斌和独立跟踪 issue #4。
- 明确 LatchMoE 只负责地址稳定 slot、Host Store/H2D、graph replay 生命周期、wave prefill 和通用 plan adapter。
- 明确 Static/Frequency/RouteTransition、EPLB matched comparison 与实验编排属于独立的 Ascend MoE Control 课题。
- 明确 graph 验证不得由强制 eager 替代。

这是文档边界调整，不修改运行时代码或既有实验结果。
