### PR TITLE
Manage graph suite through pinned launcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "third_party/vllm-hust-dev-hub"]
+	path = third_party/vllm-hust-dev-hub
+	url = https://github.com/vLLM-HUST/vllm-hust-dev-hub.git
+	branch = main

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -126,3 +126,11 @@ Each benchmark unit writes:
 
 Failed units still write `unit_result.json`; expected OOM or graph-capture
 failures are evidence, not missing data.
+# Managed graph-mode launch
+
+Non-dry suite runs start and stop the service only through the pinned
+`third_party/vllm-hust-dev-hub/manage.sh`. Supply physical NPU5 or NPU6, an
+immutable image digest, a unique container name, and a release-ack directory.
+The runner rejects occupied ports/devices, active custody units, forced eager,
+and external manager paths. `--no-start-server` remains a probe mode and must
+not be labeled repository-owned online evidence.

--- a/benchmark/scripts/run_suite.py
+++ b/benchmark/scripts/run_suite.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import signal
+import re
+import socket
 import subprocess
 import sys
 import time
@@ -34,6 +35,8 @@ from sew_bench import (  # noqa: E402
 
 
 DEFAULT_OUTPUT_ROOT = Path("benchmark/artifacts/runs")
+DEFAULT_MANAGER = Path("third_party/vllm-hust-dev-hub/manage.sh")
+IMAGE_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,6 +47,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--workload", action="append", default=[])
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--no-start-server", action="store_true")
+    parser.add_argument("--server-manager", default=str(DEFAULT_MANAGER))
+    parser.add_argument("--device", type=int, choices=(5, 6))
+    parser.add_argument("--runtime-image")
+    parser.add_argument("--runtime-image-digest")
+    parser.add_argument("--container-name")
+    parser.add_argument("--custody-unit-prefix", default="latchmoe-suite")
+    parser.add_argument("--release-ack-dir")
     parser.add_argument("--python", default=sys.executable)
     parser.add_argument("--startup-timeout-s", type=float)
     parser.add_argument(
@@ -72,14 +82,14 @@ def _health_url(config: dict[str, Any]) -> str:
     return f"http://{server['host']}:{int(server['port'])}/v1/models"
 
 
-def _wait_for_server(url: str, proc: subprocess.Popen[Any] | None, timeout_s: float) -> None:
+def _wait_for_server(
+    url: str, proc: subprocess.Popen[Any] | None, timeout_s: float
+) -> None:
     deadline = time.monotonic() + float(timeout_s)
     last_error = ""
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     request = urllib.request.Request(url, headers={"Connection": "close"})
     while time.monotonic() < deadline:
-        if proc is not None and proc.poll() is not None:
-            raise RuntimeError(f"server exited early with code {proc.returncode}")
         try:
             with opener.open(request, timeout=5) as resp:
                 if 200 <= int(resp.status) < 500:
@@ -90,22 +100,106 @@ def _wait_for_server(url: str, proc: subprocess.Popen[Any] | None, timeout_s: fl
     raise TimeoutError(f"server did not become ready at {url}: {last_error}")
 
 
-def _terminate_process_group(proc: subprocess.Popen[Any], timeout_s: float) -> None:
-    if proc.poll() is not None:
-        return
-    try:
-        os.killpg(proc.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        return
-    deadline = time.monotonic() + float(timeout_s)
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            return
-        time.sleep(1)
-    try:
-        os.killpg(proc.pid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass
+def _manager_path(value: str) -> Path:
+    expected = (Path(__file__).resolve().parents[2] / DEFAULT_MANAGER).resolve()
+    candidate = Path(value).resolve()
+    if candidate != expected or not candidate.is_file() or not os.access(candidate, os.X_OK):
+        raise ValueError("server manager must be the pinned repository dev-hub manage.sh")
+    return candidate
+
+
+def _assert_port_free(port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError as exc:
+            raise RuntimeError(f"port {port} is occupied; refusing server reuse") from exc
+
+
+def _assert_device_free(device: int) -> None:
+    completed = subprocess.run(
+        ["npu-smi", "info", "-t", "proc-mem", "-i", str(device)],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if "No process in device." not in completed.stdout:
+        raise RuntimeError(f"NPU{device} is occupied; refusing to continue")
+
+
+def _managed_env(
+    config: dict[str, Any],
+    case: dict[str, Any],
+    unit_dir: Path,
+    args: argparse.Namespace,
+) -> dict[str, str]:
+    if args.device not in {5, 6}:
+        raise ValueError("a physical --device 5 or 6 is required")
+    if not args.runtime_image or not IMAGE_DIGEST.fullmatch(str(args.runtime_image_digest or "")):
+        raise ValueError("an immutable runtime image and sha256 digest are required")
+    if not args.container_name:
+        raise ValueError("a unique --container-name is required")
+    unit_name = f"{args.custody_unit_prefix}-{unit_dir.parent.name}-{unit_dir.name}.service"
+    if len(unit_name) > 200 or not re.fullmatch(r"[A-Za-z0-9_.@-]+\.service", unit_name):
+        raise ValueError("generated custody unit name is invalid")
+    server = config["server"]
+    shape = config["serving_shape"]
+    model = config["model"]
+    image = str(args.runtime_image).split("@", 1)[0]
+    env = _unit_env(case, unit_dir)
+    env.update(
+        {
+            "VLLM_ENGINE_SYSTEMD_UNIT": unit_name,
+            "VLLM_ENGINE_CONTAINER": str(args.container_name),
+            "VLLM_ENGINE_IMAGE": f"{image}@{args.runtime_image_digest}",
+            "VLLM_ENGINE_AUTO_CREATE_CONTAINER": "true",
+            "VLLM_ENGINE_RECREATE_CONTAINER": "false",
+            "VLLM_ENGINE_REPLACE_EXISTING": "false",
+            "VLLM_ENGINE_MODEL_PATH": str(model["path"]),
+            "VLLM_ENGINE_SERVED_MODEL_NAME": str(model["served_model_name"]),
+            "VLLM_ENGINE_PORT": str(server["port"]),
+            "VLLM_ENGINE_TP_SIZE": str(model["tensor_parallel_size"]),
+            "VLLM_ENGINE_NPU_DEVICES": str(args.device),
+            "VLLM_ENGINE_MAX_MODEL_LEN": str(shape["max_model_len"]),
+            "VLLM_ENGINE_MAX_NUM_BATCHED_TOKENS": str(shape["max_num_batched_tokens"]),
+            "VLLM_ENGINE_MAX_NUM_SEQS": str(shape["max_num_seqs"]),
+            "VLLM_ENGINE_GPU_MEM_UTIL": str(shape["gpu_memory_utilization"]),
+            "VLLM_ENGINE_DTYPE": str(model["dtype"]),
+            "VLLM_ENGINE_ENFORCE_EAGER": "0",
+            "VLLM_ENGINE_EXTRA_ARGS_JSON": json.dumps(
+                ["--trust-remote-code", *[str(item) for item in case.get("server_args", [])]]
+            ),
+            "VLLM_OPTIMIZATION_REPO_CONTAINER": "/workspace/vllm-ascend-hust-LatchMoE",
+            "VLLM_OPTIMIZATION_SRC_SUBDIR": "",
+            "VLLM_ENGINE_EXTRA_ENV_PREFIXES": "VLLM_ASCEND_MOE_",
+        }
+    )
+    forbidden = json.dumps({key: value for key, value in env.items() if key.startswith("VLLM_ENGINE")}).lower()
+    if "--enforce-eager" in forbidden or '"vllm_engine_enforce_eager":"1"' in forbidden.replace(" ", ""):
+        raise ValueError("forced eager is forbidden")
+    return env
+
+
+def _manager_call(manager: Path, action: str, env: dict[str, str], log_path: Path, *, check: bool) -> subprocess.CompletedProcess[str]:
+    command = [str(manager), action]
+    if action in {"status", "health"}:
+        command.append("--json")
+    completed = subprocess.run(
+        command,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{time.time_ns()}] {action} rc={completed.returncode}\n{completed.stdout}")
+        if completed.stdout and not completed.stdout.endswith("\n"):
+            handle.write("\n")
+    if check and completed.returncode != 0:
+        raise RuntimeError(f"managed launcher {action} failed with code {completed.returncode}")
+    return completed
 
 
 def _unit_env(case: dict[str, Any], unit_dir: Path) -> dict[str, str]:
@@ -209,25 +303,28 @@ def run_unit(
 
     server_log_path = unit_dir / "server.log"
     client_log_path = unit_dir / "client.log"
-    server_proc: subprocess.Popen[Any] | None = None
+    manager: Path | None = None
+    managed_env: dict[str, str] | None = None
+    release_status = "not-started"
     try:
         if not args.no_start_server:
-            with server_log_path.open("w", encoding="utf-8") as server_log:
-                server_proc = subprocess.Popen(
-                    server_cmd,
-                    cwd=Path.cwd(),
-                    env=env,
-                    stdout=server_log,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    start_new_session=True,
-                )
+            manager = _manager_path(args.server_manager)
+            _assert_port_free(int(config["server"]["port"]))
+            _assert_device_free(int(args.device))
+            managed_env = _managed_env(config, case, unit_dir, args)
+            status = _manager_call(manager, "status", managed_env, server_log_path, check=False)
+            if status.returncode == 0:
+                payload = json.loads(status.stdout.strip().splitlines()[-1])
+                if payload.get("active_state") == "active" or int(payload.get("main_pid", 0)) > 0:
+                    raise RuntimeError("custody unit is active; refusing server reuse")
+            _manager_call(manager, "start", managed_env, server_log_path, check=True)
+            release_status = "started"
             timeout_s = (
                 float(args.startup_timeout_s)
                 if args.startup_timeout_s is not None
                 else float(config["server"].get("startup_timeout_s", 1200))
             )
-            _wait_for_server(_health_url(config), server_proc, timeout_s)
+            _wait_for_server(_health_url(config), None, timeout_s)
 
         with client_log_path.open("w", encoding="utf-8") as client_log:
             completed = subprocess.run(
@@ -276,11 +373,27 @@ def run_unit(
         _write_unit_markdown(unit_dir, result)
         return result
     finally:
-        if server_proc is not None:
-            _terminate_process_group(
-                server_proc,
-                float(config["server"].get("shutdown_timeout_s", 30)),
-            )
+        if manager is not None and managed_env is not None:
+            _manager_call(manager, "stop", managed_env, server_log_path, check=False)
+            status = _manager_call(manager, "status", managed_env, server_log_path, check=False)
+            if status.returncode == 0:
+                payload = json.loads(status.stdout.strip().splitlines()[-1])
+                if payload.get("active_state") == "active" or int(payload.get("main_pid", 0)) > 0:
+                    release_status = "release-failed"
+                else:
+                    release_status = "released"
+            if args.release_ack_dir:
+                ack_dir = Path(args.release_ack_dir)
+                ack_dir.mkdir(parents=True, exist_ok=True)
+                write_json(
+                    ack_dir / f"{unit_dir.parent.name}-{unit_dir.name}.json",
+                    {
+                        "custody_unit": managed_env["VLLM_ENGINE_SYSTEMD_UNIT"],
+                        "device": args.device,
+                        "released_at_ns": time.time_ns(),
+                        "status": release_status,
+                    },
+                )
 
 
 def _write_suite_summary(suite_dir: Path, results: list[dict[str, Any]]) -> None:
@@ -318,6 +431,17 @@ def main() -> int:
         for issue in issues:
             print(f"ERROR {issue}", file=sys.stderr)
         return 1
+
+    if not args.dry_run and not args.no_start_server:
+        if not args.release_ack_dir:
+            print("ERROR --release-ack-dir is required for managed runs", file=sys.stderr)
+            return 1
+        try:
+            _manager_path(args.server_manager)
+            _managed_env(config, select_cases(config, args.case or None)[0], Path("probe/cell"), args)
+        except (ValueError, OSError) as exc:
+            print(f"ERROR {exc}", file=sys.stderr)
+            return 1
 
     cases = select_cases(config, args.case or None)
     workloads = select_workloads(config, args.workload or None)

--- a/tests/test_managed_suite.py
+++ b/tests/test_managed_suite.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SUITE_PATH = REPO_ROOT / "benchmark" / "scripts" / "run_suite.py"
+
+
+def _load_run_suite():
+    spec = importlib.util.spec_from_file_location("managed_run_suite_test", RUN_SUITE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**updates: object) -> Namespace:
+    values = {
+        "device": 5,
+        "runtime_image": "registry.example/vllm-ascend:known",
+        "runtime_image_digest": "sha256:" + "a" * 64,
+        "container_name": "latchmoe-test",
+        "custody_unit_prefix": "latchmoe",
+    }
+    values.update(updates)
+    return Namespace(**values)
+
+
+def _config() -> dict:
+    return {
+        "server": {"port": 8026},
+        "model": {
+            "path": "/data/model",
+            "served_model_name": "model",
+            "tensor_parallel_size": 1,
+            "dtype": "bfloat16",
+        },
+        "serving_shape": {
+            "max_model_len": 4096,
+            "max_num_batched_tokens": 4096,
+            "max_num_seqs": 1,
+            "gpu_memory_utilization": 0.9,
+        },
+    }
+
+
+def test_managed_env_pins_graph_device_and_digest(tmp_path: Path) -> None:
+    env = _load_run_suite()._managed_env(
+        _config(), {"server_args": [], "env": {}}, tmp_path / "case/work", _args()
+    )
+    assert env["VLLM_ENGINE_NPU_DEVICES"] == "5"
+    assert env["VLLM_ENGINE_ENFORCE_EAGER"] == "0"
+    assert "@sha256:" in env["VLLM_ENGINE_IMAGE"]
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"device": 7},
+        {"runtime_image_digest": "latest"},
+        {"container_name": ""},
+    ],
+)
+def test_managed_env_rejects_incomplete_custody(tmp_path: Path, updates: dict) -> None:
+    with pytest.raises(ValueError):
+        _load_run_suite()._managed_env(
+            _config(),
+            {"server_args": [], "env": {}},
+            tmp_path / "case/work",
+            _args(**updates),
+        )
+
+
+def test_managed_env_rejects_forced_eager(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="forced eager"):
+        _load_run_suite()._managed_env(
+            _config(),
+            {"server_args": ["--enforce-eager"], "env": {}},
+            tmp_path / "case/work",
+            _args(),
+        )


### PR DESCRIPTION
## Summary

- Pin `vllm-hust-dev-hub` as a repository submodule and use its manager for every non-probe service start.
- Remove direct `Popen(vllm)` service ownership from the benchmark suite.
- Require physical NPU5 or NPU6, an immutable image digest, a unique container, a custody unit, and a release-ack directory.
- Refuse occupied devices and ports, active custody units, forced eager, external manager paths, and replacement of an existing service.
- Stop every service through the same manager and retain a release acknowledgement for successful and failed units.

## Verification

- 15 benchmark-design and managed-suite tests passed.
- Ruff passed on the changed Python files.
- Canonical `sew_14gb_autoslots × smoke` dry-run passed.
- `git diff --check` passed.

The wider runtime test suite still cannot be collected in the available host environment because it lacks a usable `vllm_ascend`/CANN runtime. No NPU service was started, and no online performance claim is made. The next graph correctness smoke requires an approved immutable image digest and a fresh custody identity.
