### PR TITLE
fix: qualify graph warmup waves for shared MoE

### DIFF
--- a/benchmark/registry/qualification_matrix_v2.json
+++ b/benchmark/registry/qualification_matrix_v2.json
@@ -74,21 +74,25 @@
       },
       "checkpoint_index_sha256": "91e6e95ca21700f50904a680c8c4212f5aa16dc7c10a013f01c906957c889791",
       "config_sha256": "dc9b97c7c9bed726a2e6939da4234d5c43abb3edec8812068c9a1af1dbc13acb",
+      "evidence": {
+        "qualification_report": "/workspace/latchmoe-issue27-npu5/glm-phase-b-r13/qualification_report.json",
+        "qualification_report_sha256": "61000f919b4a1a6f8961d345e4aa640e570e813a8aacf495f8b61189393b3b74"
+      },
       "gates": {
-        "decode_cache_churn": "not_run",
-        "h2d_lease_release": "not_run",
-        "latchmoe_eager_diagnostic": "not_run",
-        "layer_boundary_parity": "not_run",
-        "native_oracle": "not_run",
-        "piecewise_capture": "not_run",
-        "piecewise_replay": "not_run",
-        "prefill_overflow": "not_run",
-        "router_parity": "not_run",
-        "token_exactness": "not_run",
-        "zero_eager_fallback": "not_run"
+        "decode_cache_churn": "passed",
+        "h2d_lease_release": "passed",
+        "latchmoe_eager_diagnostic": "passed",
+        "layer_boundary_parity": "passed",
+        "native_oracle": "passed",
+        "piecewise_capture": "passed",
+        "piecewise_replay": "passed",
+        "prefill_overflow": "passed",
+        "router_parity": "passed",
+        "token_exactness": "passed",
+        "zero_eager_fallback": "passed"
       },
       "id": "glm-4.7-flash",
-      "status": "not_run"
+      "status": "passed"
     },
     {
       "capability_config": {
@@ -118,21 +122,25 @@
       },
       "checkpoint_index_sha256": "0e5274f538d750abdd7fd55a36bad64100f9e881d59c65f6a59f364d2f8b6dd7",
       "config_sha256": "2d483c7cabad7c8704478ed4038fa7e7b2eff840bc00a118eccbe38e2b488303",
+      "evidence": {
+        "qualification_report": "/root/workspace/latchmoe-issue27-npu5/qwen3-next-gdn-vendor-r14/qualification_report.json",
+        "qualification_report_sha256": "eb35ad23d847d07430b550e497ca2fd5406eabf89d425a6b18bfd435d4b071d4"
+      },
       "gates": {
-        "decode_cache_churn": "not_run",
-        "h2d_lease_release": "not_run",
-        "latchmoe_eager_diagnostic": "not_run",
-        "layer_boundary_parity": "not_run",
-        "native_oracle": "not_run",
-        "piecewise_capture": "not_run",
-        "piecewise_replay": "not_run",
-        "prefill_overflow": "not_run",
-        "router_parity": "not_run",
-        "token_exactness": "not_run",
-        "zero_eager_fallback": "not_run"
+        "decode_cache_churn": "passed",
+        "h2d_lease_release": "passed",
+        "latchmoe_eager_diagnostic": "passed",
+        "layer_boundary_parity": "passed",
+        "native_oracle": "passed",
+        "piecewise_capture": "passed",
+        "piecewise_replay": "passed",
+        "prefill_overflow": "passed",
+        "router_parity": "passed",
+        "token_exactness": "passed",
+        "zero_eager_fallback": "passed"
       },
       "id": "qwen3-next-80b-a3b-instruct",
-      "status": "not_run"
+      "status": "passed"
     }
   ],
   "schema_version": "latchmoe-qualification-matrix-v2"

--- a/benchmark/scripts/run_fixed_slot_smoke.py
+++ b/benchmark/scripts/run_fixed_slot_smoke.py
@@ -48,8 +48,18 @@ SEW_OFFLOAD_ENV_VARS = (
     "VLLM_ASCEND_MOE_OFFLOAD_RESIDENT_LAYER_IDS",
     "VLLM_ASCEND_MOE_OFFLOAD_RELEASE_ORIGINAL_EXPERT_WEIGHTS",
     "VLLM_ASCEND_MOE_OFFLOAD_LAYERED_RUNTIME",
+    "VLLM_ASCEND_MOE_OFFLOAD_GRAPH_COMPATIBLE",
     "VLLM_ASCEND_MOE_OFFLOAD_FANOUT_THRESHOLD",
     "VLLM_ASCEND_MOE_OFFLOAD_PROFILE_PATH",
+    "VLLM_ASCEND_MOE_OFFLOAD_STAGE_SEAM",
+    "VLLM_ASCEND_MOE_OFFLOAD_CPU_FIRST_LOAD",
+    "VLLM_ASCEND_MOE_OFFLOAD_COMPARE_ROUTER",
+    "VLLM_ASCEND_MOE_OFFLOAD_COMPARE_LAYER_BOUNDARY",
+    "VLLM_ASCEND_MOE_OFFLOAD_B2_WAVE_PREFILL",
+    "VLLM_ASCEND_MOE_OFFLOAD_B2_OVERFLOW_MODE",
+    "VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT",
+    "VLLM_ASCEND_MOE_ROUTER_PARITY_PATH",
+    "VLLM_ASCEND_MOE_ROUTER_PARITY_MAX_TOKENS",
 )
 
 
@@ -86,12 +96,43 @@ def parse_args() -> argparse.Namespace:
         help="Disable vLLM and Ascend norm-quant compiler passes for CANN compatibility probes.",
     )
     parser.add_argument("--enforce-eager", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument(
+        "--diagnostic-eager",
+        action="store_true",
+        help="Allow eager execution only for an explicitly labelled qualification diagnostic.",
+    )
     parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--num-slots", type=int, default=16)
     parser.add_argument("--resident-layer-ids", default="")
     parser.add_argument("--release-original-expert-weights", action="store_true")
     parser.add_argument("--layered-runtime", action="store_true")
     parser.add_argument("--fanout-threshold", type=int, default=0)
+    parser.add_argument(
+        "--stage-seam",
+        action="store_true",
+        help="Enable the graph splitting seam for a fixed-slot qualification run.",
+    )
+    parser.add_argument(
+        "--cpu-first-load",
+        action="store_true",
+        help="Load routed expert weights CPU-first before fixed-slot registration.",
+    )
+    parser.add_argument(
+        "--router-parity",
+        action="store_true",
+        help="Capture bounded native and seam router snapshots in eager diagnostics.",
+    )
+    parser.add_argument("--router-parity-max-tokens", type=int, default=64)
+    parser.add_argument(
+        "--layer-boundary-parity",
+        action="store_true",
+        help="Compare native and seam MoE tuple outputs in eager diagnostics.",
+    )
+    parser.add_argument(
+        "--wave-prefill",
+        action="store_true",
+        help="Enable the multi-wave prefill qualification path.",
+    )
     parser.add_argument("--offload-backend", default="prefetch")
     parser.add_argument("--offload-group-size", type=int, default=4)
     parser.add_argument("--offload-num-in-group", type=int, default=1)
@@ -108,8 +149,20 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     args = parser.parse_args()
-    if args.enforce_eager:
-        parser.error("--enforce-eager is forbidden for graph-only LatchMoE runs")
+    if args.enforce_eager and not args.diagnostic_eager:
+        parser.error("--enforce-eager requires --diagnostic-eager")
+    if args.diagnostic_eager and not args.enforce_eager:
+        parser.error("--diagnostic-eager requires --enforce-eager")
+    if args.stage_seam and args.mode != "fixed_slot_sync":
+        parser.error("--stage-seam requires --mode fixed_slot_sync")
+    if args.cpu_first_load and not args.stage_seam:
+        parser.error("--cpu-first-load requires --stage-seam")
+    if args.router_parity and (not args.stage_seam or not args.diagnostic_eager):
+        parser.error("--router-parity requires an eager fixed-slot seam diagnostic")
+    if args.layer_boundary_parity and (not args.stage_seam or not args.diagnostic_eager):
+        parser.error("--layer-boundary-parity requires an eager fixed-slot seam diagnostic")
+    if args.wave_prefill and not args.stage_seam:
+        parser.error("--wave-prefill requires --stage-seam")
     return args
 
 
@@ -176,6 +229,7 @@ def configure_sew_offload_env(
     mode: str,
     *,
     num_slots: int,
+    max_num_seqs_hint: int | None = None,
     resident_layer_ids: str = "",
     release_original_expert_weights: bool = False,
     layered_runtime: bool = False,
@@ -204,7 +258,16 @@ def configure_sew_offload_env(
         "1" if release_original_expert_weights else "0"
     )
     os.environ["VLLM_ASCEND_MOE_OFFLOAD_LAYERED_RUNTIME"] = "1" if layered_runtime else "0"
+    os.environ["VLLM_ASCEND_MOE_OFFLOAD_GRAPH_COMPATIBLE"] = (
+        "1" if mode == "fixed_slot_sync" else "0"
+    )
     os.environ["VLLM_ASCEND_MOE_OFFLOAD_FANOUT_THRESHOLD"] = str(int(fanout_threshold))
+    if max_num_seqs_hint is not None:
+        if int(max_num_seqs_hint) <= 0:
+            raise ValueError("max_num_seqs_hint must be greater than zero")
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT"] = str(
+            int(max_num_seqs_hint)
+        )
     os.environ.setdefault("VLLM_ASCEND_MOE_OFFLOAD_PROFILE_PATH", "moe_offload_profile.jsonl")
 
 
@@ -393,12 +456,35 @@ def run_smoke(
     configure_sew_offload_env(
         mode,
         num_slots=args.num_slots,
+        max_num_seqs_hint=(
+            int(args.max_num_seqs)
+            if bool(getattr(args, "wave_prefill", False))
+            else None
+        ),
         resident_layer_ids=getattr(args, "resident_layer_ids", ""),
         release_original_expert_weights=getattr(args, "release_original_expert_weights", False),
         layered_runtime=getattr(args, "layered_runtime", False),
         fanout_threshold=getattr(args, "fanout_threshold", 0),
         trace_path=str(trace_jsonl_path),
     )
+    router_parity_path = output_dir / "moe_router_parity.jsonl"
+    if bool(getattr(args, "stage_seam", False)):
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_STAGE_SEAM"] = "1"
+    if bool(getattr(args, "cpu_first_load", False)):
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_CPU_FIRST_LOAD"] = "1"
+    if bool(getattr(args, "router_parity", False)):
+        if router_parity_path.exists():
+            router_parity_path.unlink()
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_COMPARE_ROUTER"] = "1"
+        os.environ["VLLM_ASCEND_MOE_ROUTER_PARITY_PATH"] = str(router_parity_path)
+        os.environ["VLLM_ASCEND_MOE_ROUTER_PARITY_MAX_TOKENS"] = str(
+            max(1, int(getattr(args, "router_parity_max_tokens", 64)))
+        )
+    if bool(getattr(args, "layer_boundary_parity", False)):
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_COMPARE_LAYER_BOUNDARY"] = "1"
+    if bool(getattr(args, "wave_prefill", False)):
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_B2_WAVE_PREFILL"] = "1"
+        os.environ["VLLM_ASCEND_MOE_OFFLOAD_B2_OVERFLOW_MODE"] = "multi_wave"
     if mode != "no_offload":
         os.environ["VLLM_ASCEND_MOE_OFFLOAD_PROFILE_PATH"] = str(profile_jsonl_path)
         # vLLM selects a single platform plugin; explicitly install LatchMoE hooks.
@@ -432,6 +518,9 @@ def run_smoke(
             "model": llm_kwargs["model"],
             "num_slots": int(args.num_slots) if mode == "fixed_slot_sync" else 0,
             "layered_runtime": bool(getattr(args, "layered_runtime", False)) if mode == "fixed_slot_sync" else False,
+            "graph_compatible_offload": bool(
+                mode == "fixed_slot_sync"
+            ),
             "fanout_threshold": int(getattr(args, "fanout_threshold", 0)) if mode == "fixed_slot_sync" else 0,
             "disable_ascend_norm_quant_fusion": bool(
                 getattr(args, "disable_ascend_norm_quant_fusion", False)
@@ -442,6 +531,25 @@ def run_smoke(
             "moe_offload_profile": get_moe_offload_runtime().profiling_summary(),
             "moe_offload_profile_jsonl": str(profile_jsonl_path),
             "moe_offload_profile_jsonl_events": _read_profile_jsonl(profile_jsonl_path),
+            "qualification_diagnostics": {
+                "diagnostic_eager": bool(getattr(args, "diagnostic_eager", False)),
+                "stage_seam": bool(getattr(args, "stage_seam", False)),
+                "cpu_first_load": bool(getattr(args, "cpu_first_load", False)),
+                "release_original_expert_weights": bool(
+                    getattr(args, "release_original_expert_weights", False)
+                ),
+                "graph_compatible_offload": bool(mode == "fixed_slot_sync"),
+                "router_parity": bool(getattr(args, "router_parity", False)),
+                "router_parity_artifact": (
+                    str(router_parity_path)
+                    if bool(getattr(args, "router_parity", False))
+                    else None
+                ),
+                "layer_boundary_parity": bool(
+                    getattr(args, "layer_boundary_parity", False)
+                ),
+                "wave_prefill": bool(getattr(args, "wave_prefill", False)),
+            },
         }
     )
     (output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")

--- a/benchmark/scripts/run_issue27_qualification.py
+++ b/benchmark/scripts/run_issue27_qualification.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Run the native/eager/PIECEWISE Issue #27 qualification bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE = REPO_ROOT / "benchmark" / "scripts" / "run_fixed_slot_smoke.py"
+
+_PREFLIGHT_MODULES = ("acl", "torch", "torch_npu", "vllm", "vllm_ascend")
+_PREFLIGHT_CODE = r'''
+import importlib
+import json
+import os
+import sys
+
+result = {
+    "python": sys.executable,
+    "python_version": sys.version,
+    "prefix": sys.prefix,
+    "ascend_home_path": os.environ.get("ASCEND_HOME_PATH"),
+    "pythonpath": os.environ.get("PYTHONPATH"),
+    "modules": {},
+}
+for module_name in %r:
+    try:
+        module = importlib.import_module(module_name)
+        result["modules"][module_name] = {
+            "status": "ok",
+            "path": getattr(module, "__file__", None),
+            "version": getattr(module, "__version__", None),
+        }
+    except Exception as exc:
+        result["modules"][module_name] = {
+            "status": "failed",
+            "type": type(exc).__name__,
+            "error": str(exc),
+        }
+print(json.dumps(result, sort_keys=True))
+'''
+
+
+def _environment_preflight(python: str, env: dict[str, str]) -> dict[str, Any]:
+    """Check the imports required by both the parent and EngineCore process."""
+    code = _PREFLIGHT_CODE % (_PREFLIGHT_MODULES,)
+    completed = subprocess.run(
+        [python, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    try:
+        result = json.loads(stdout_lines[-1])
+    except (IndexError, json.JSONDecodeError):
+        result = {
+            "modules": {},
+            "stdout": completed.stdout[-4000:],
+            "stderr": completed.stderr[-4000:],
+        }
+    modules = result.get("modules") or {}
+    failures = {
+        module: detail
+        for module, detail in modules.items()
+        if detail.get("status") != "ok"
+    }
+    result["returncode"] = int(completed.returncode)
+    result["status"] = "passed" if completed.returncode == 0 and not failures else "failed"
+    result["failed_modules"] = failures
+    if completed.stderr.strip():
+        result["stderr"] = completed.stderr[-4000:]
+    return result
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--model-path", required=True, type=Path)
+    parser.add_argument("--output-root", required=True, type=Path)
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--device", type=int, choices=(5, 6), required=True)
+    # Profile/dummy forwards choose B2 automatically when their observed union
+    # exceeds the fixed slot capacity. Keep this low enough to exercise actual
+    # offload rather than masking the capacity mechanism with near-residency.
+    parser.add_argument("--num-slots", type=int, default=32)
+    parser.add_argument("--overflow-slots", type=int, default=4)
+    parser.add_argument("--output-tokens", type=int, default=4)
+    parser.add_argument("--max-model-len", type=int, default=256)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=256)
+    parser.add_argument("--kv-cache-memory-mb", type=int, default=128)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.96)
+    parser.add_argument(
+        "--prompt",
+        default="Hi",
+    )
+    parser.add_argument(
+        "--overflow-prompt",
+        default=(
+            "Read this repeated qualification context and answer with one concise sentence. "
+            # Keep the default pressure prompt below the 256-token smoke
+            # contract while still producing a multi-wave routed union.
+            + "The routed expert workload must remain deterministic. " * 24
+        ),
+    )
+    return parser.parse_args()
+
+
+def _base_command(args: argparse.Namespace, unit_dir: Path, *, mode: str, prompt: str, output_tokens: int, slots: int) -> list[str]:
+    command = [
+        str(args.python),
+        str(SMOKE),
+        "--mode",
+        mode,
+        "--model",
+        str(args.model_path.resolve()),
+        "--output-dir",
+        str(unit_dir),
+        "--inline-prompt",
+        prompt,
+        "--inline-max-output-tokens",
+        str(int(output_tokens)),
+        "--max-model-len",
+        str(int(args.max_model_len)),
+        "--max-num-batched-tokens",
+        str(int(args.max_num_batched_tokens)),
+        "--kv-cache-memory-mb",
+        str(int(args.kv_cache_memory_mb)),
+        "--gpu-memory-utilization",
+        str(float(args.gpu_memory_utilization)),
+        "--num-slots",
+        str(int(slots)),
+        "--ignore-eos",
+        "--disable-ascend-norm-quant-fusion",
+    ]
+    return command
+
+
+def _run_unit(
+    args: argparse.Namespace,
+    *,
+    name: str,
+    mode: str,
+    prompt: str,
+    output_tokens: int,
+    slots: int,
+    diagnostic_eager: bool = False,
+    stage_seam: bool = False,
+    cpu_first_load: bool = False,
+    release_original_expert_weights: bool = False,
+    router_parity: bool = False,
+    layer_boundary_parity: bool = False,
+    wave_prefill: bool = False,
+) -> dict[str, Any]:
+    unit_dir = args.output_root / name
+    unit_dir.mkdir(parents=True, exist_ok=False)
+    command = _base_command(
+        args,
+        unit_dir,
+        mode=mode,
+        prompt=prompt,
+        output_tokens=output_tokens,
+        slots=slots,
+    )
+    if diagnostic_eager:
+        command.extend(["--enforce-eager", "--diagnostic-eager"])
+    if stage_seam:
+        command.append("--stage-seam")
+        if cpu_first_load:
+            command.append("--cpu-first-load")
+        if release_original_expert_weights:
+            command.append("--release-original-expert-weights")
+        command.append("--layered-runtime")
+    if router_parity:
+        command.extend(["--router-parity", "--router-parity-max-tokens", "64"])
+    if layer_boundary_parity:
+        command.append("--layer-boundary-parity")
+    if wave_prefill:
+        command.append("--wave-prefill")
+
+    env = dict(os.environ)
+    env["ASCEND_RT_VISIBLE_DEVICES"] = str(args.device)
+    env["ASCEND_VISIBLE_DEVICES"] = str(args.device)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    log_path = unit_dir / "run.log"
+    (unit_dir / "unit_manifest.json").write_text(
+        json.dumps(
+            {
+                "model_id": args.model_id,
+                "model_path": str(args.model_path.resolve()),
+                "unit": name,
+                "command": command,
+                "device": int(args.device),
+                "qualification": {
+                    "diagnostic_eager": diagnostic_eager,
+                    "stage_seam": stage_seam,
+                    "cpu_first_load": cpu_first_load,
+                    "release_original_expert_weights": release_original_expert_weights,
+                    "router_parity": router_parity,
+                    "layer_boundary_parity": layer_boundary_parity,
+                    "wave_prefill": wave_prefill,
+                },
+                "environment": {
+                    key: env.get(key)
+                    for key in (
+                        "ASCEND_RT_VISIBLE_DEVICES",
+                        "ASCEND_VISIBLE_DEVICES",
+                        "ASCEND_HOME_PATH",
+                        "ASCEND_TOOLKIT_HOME",
+                        "PYTHONPATH",
+                        "LD_LIBRARY_PATH",
+                        "PYTORCH_NPU_ALLOC_CONF",
+                        "VLLM_ASCEND_MOE_OFFLOAD_STAGE_SEAM",
+                        "VLLM_ASCEND_MOE_OFFLOAD_CPU_FIRST_LOAD",
+                    )
+                    if env.get(key) is not None
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with log_path.open("w", encoding="utf-8") as log:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+            text=True,
+        )
+    return {
+        "unit": name,
+        "unit_dir": str(unit_dir),
+        "returncode": int(completed.returncode),
+        "status": "ok" if completed.returncode == 0 else "failed",
+        "command": command,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    args.model_path = args.model_path.resolve()
+    args.output_root = args.output_root.resolve()
+    if not args.model_path.is_dir():
+        raise FileNotFoundError(args.model_path)
+    if args.output_root.exists():
+        raise FileExistsError(
+            f"refusing to overwrite an existing qualification bundle: {args.output_root}"
+        )
+    args.output_root.mkdir(parents=True)
+
+    env = dict(os.environ)
+    env["ASCEND_RT_VISIBLE_DEVICES"] = str(args.device)
+    env["ASCEND_VISIBLE_DEVICES"] = str(args.device)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+    preflight = _environment_preflight(str(args.python), env)
+    preflight["created_at"] = datetime.now(timezone.utc).isoformat()
+    (args.output_root / "environment_preflight.json").write_text(
+        json.dumps(preflight, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if preflight["status"] != "passed":
+        manifest = {
+            "schema_version": "latchmoe-issue27-qualification-bundle-v1",
+            "model_id": args.model_id,
+            "model_path": str(args.model_path),
+            "device": int(args.device),
+            "status": "blocked",
+            "blocked_reason": "qualification environment preflight failed",
+            "environment_preflight": "environment_preflight.json",
+            "units": [],
+        }
+        (args.output_root / "bundle_manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+        return 2
+
+    units = [
+        _run_unit(
+            args,
+            name="native-eager",
+            mode="no_offload",
+            prompt=args.prompt,
+            output_tokens=args.output_tokens,
+            slots=0,
+            diagnostic_eager=True,
+        ),
+        _run_unit(
+            args,
+            name="latch-eager",
+            mode="fixed_slot_sync",
+            prompt=args.prompt,
+            output_tokens=args.output_tokens,
+            slots=args.num_slots,
+            diagnostic_eager=True,
+            stage_seam=True,
+            cpu_first_load=True,
+            release_original_expert_weights=True,
+            router_parity=True,
+            layer_boundary_parity=True,
+        ),
+        _run_unit(
+            args,
+            name="latch-graph",
+            mode="fixed_slot_sync",
+            prompt=args.prompt,
+            output_tokens=args.output_tokens,
+            slots=args.num_slots,
+            stage_seam=True,
+            cpu_first_load=True,
+            release_original_expert_weights=True,
+        ),
+        _run_unit(
+            args,
+            name="overflow-graph",
+            mode="fixed_slot_sync",
+            prompt=args.overflow_prompt,
+            output_tokens=1,
+            slots=args.overflow_slots,
+            stage_seam=True,
+            cpu_first_load=True,
+            release_original_expert_weights=True,
+            wave_prefill=True,
+        ),
+    ]
+    manifest = {
+        "schema_version": "latchmoe-issue27-qualification-bundle-v1",
+        "model_id": args.model_id,
+        "model_path": str(args.model_path),
+        "device": int(args.device),
+        "units": units,
+    }
+    (args.output_root / "bundle_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0 if all(unit["status"] == "ok" for unit in units) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/scripts/verify_issue27_qualification.py
+++ b/benchmark/scripts/verify_issue27_qualification.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Fail closed for one Issue #27 Phase-B qualification bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vllm_moe_offload_ascend.moe_offload.router_parity import (  # noqa: E402
+    compare_router_artifacts,
+    load_router_artifact,
+)
+
+
+GATES = (
+    "native_oracle",
+    "latchmoe_eager_diagnostic",
+    "router_parity",
+    "layer_boundary_parity",
+    "token_exactness",
+    "piecewise_capture",
+    "piecewise_replay",
+    "zero_eager_fallback",
+    "h2d_lease_release",
+    "prefill_overflow",
+    "decode_cache_churn",
+)
+_LAYER_LINE = re.compile(r"SEW_LAYER_BOUNDARY_COMPARE\b")
+_FALLBACK_MARKERS = (
+    "latchmoe_capability_rejected",
+    "refusing native/eager fallback",
+    "unsupported global configuration",
+)
+_CAPACITY_FAILURE_MARKERS = (
+    "torch.OutOfMemoryError",
+    "torch_npu.OutOfMemoryError",
+    "NPU out of memory",
+    "out of memory",
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL at {path}:{line_number}") from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"non-object JSONL record at {path}:{line_number}")
+        records.append(record)
+    return records
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _outputs(unit_dir: Path) -> dict[str, list[int]]:
+    path = unit_dir / "outputs.jsonl"
+    if not path.is_file():
+        raise ValueError(f"missing output artifact: {path}")
+    result: dict[str, list[int]] = {}
+    for record in _read_jsonl(path):
+        request_id = str(record.get("request_id") or "")
+        token_ids = record.get("output_token_ids")
+        if not request_id or not isinstance(token_ids, list):
+            raise ValueError(f"invalid output record in {path}")
+        if request_id in result:
+            raise ValueError(f"duplicate request ID {request_id!r} in {path}")
+        result[request_id] = [int(token_id) for token_id in token_ids]
+    if not result or not all(result.values()):
+        raise ValueError(f"no non-empty token outputs in {path}")
+    return result
+
+
+def _same_outputs(expected: dict[str, list[int]], observed: dict[str, list[int]]) -> dict[str, Any]:
+    missing = sorted(set(expected) - set(observed))
+    extra = sorted(set(observed) - set(expected))
+    mismatched = {
+        request_id: {"expected": expected[request_id], "observed": observed[request_id]}
+        for request_id in sorted(set(expected) & set(observed))
+        if expected[request_id] != observed[request_id]
+    }
+    return {
+        "passed": not missing and not extra and not mismatched,
+        "missing_request_ids": missing,
+        "extra_request_ids": extra,
+        "mismatched": mismatched,
+    }
+
+
+def _summary_is_success(unit_dir: Path) -> tuple[bool, str | None]:
+    path = unit_dir / "summary.json"
+    if not path.is_file():
+        return False, f"missing summary: {path}"
+    summary = _read_json(path)
+    if summary.get("status") != "ok":
+        return False, f"summary status is {summary.get('status')!r}: {path}"
+    try:
+        _outputs(unit_dir)
+    except ValueError as exc:
+        return False, str(exc)
+    return True, None
+
+
+def _capacity_failure(unit_dir: Path) -> tuple[bool, dict[str, Any]]:
+    """Classify an expected full-resident capacity failure without hiding it."""
+    summary_path = unit_dir / "summary.json"
+    log_path = unit_dir / "run.log"
+    text = ""
+    for path in (summary_path, log_path):
+        if path.is_file():
+            text += "\n" + path.read_text(encoding="utf-8", errors="replace")
+    markers = [marker for marker in _CAPACITY_FAILURE_MARKERS if marker in text]
+    if not markers:
+        return False, {"status": "not_capacity_failure"}
+    return True, {
+        "status": "capacity_limited",
+        "markers": markers,
+        "summary": _read_json(summary_path) if summary_path.is_file() else {},
+    }
+
+
+def _profile(unit_dir: Path) -> list[dict[str, Any]]:
+    path = unit_dir / "moe_offload_profile.jsonl"
+    if not path.is_file():
+        raise ValueError(f"missing profile artifact: {path}")
+    return _read_jsonl(path)
+
+
+def _layer_boundary_gate(log_path: Path, *, shared_output_required: bool) -> tuple[bool, dict[str, Any]]:
+    if not log_path.is_file():
+        return False, {"reason": f"missing eager log: {log_path}"}
+    lines = [
+        line for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if _LAYER_LINE.search(line)
+    ]
+    if not lines:
+        return False, {"reason": "no layer-boundary diagnostics"}
+    failures: list[str] = []
+    for line in lines:
+        if "output_equal=True" not in line:
+            failures.append(line)
+        if shared_output_required and "shared_equal=True" not in line:
+            failures.append(line)
+        if "shared_contract_equal=False" in line:
+            failures.append(line)
+    return not failures, {"records": len(lines), "failures": failures[:8]}
+
+
+def _graph_gates(unit_dir: Path) -> dict[str, tuple[bool, dict[str, Any]]]:
+    try:
+        records = _profile(unit_dir)
+    except ValueError as exc:
+        failed = (False, {"reason": str(exc)})
+        return {
+            "piecewise_capture": failed,
+            "piecewise_replay": failed,
+            "zero_eager_fallback": failed,
+            "h2d_lease_release": failed,
+            "decode_cache_churn": failed,
+        }
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        by_name.setdefault(str(record.get("name") or ""), []).append(record)
+    log = (unit_dir / "run.log").read_text(encoding="utf-8", errors="replace") if (unit_dir / "run.log").is_file() else ""
+    locks = by_name.get("graph_slot_address_lock", [])
+    validates = by_name.get("graph_slot_address_validate", [])
+    replays = by_name.get("graph_replay_issue", [])
+    capture_ok = (
+        bool(locks)
+        and bool(validates)
+        and "LATCHMOE_GRAPH_CONFIG cudagraph_mode=PIECEWISE" in log
+        and "Graph capturing finished" in log
+    )
+    replay_ok = bool(replays) and "Replaying aclgraph" in log and all(
+        (record.get("payload") or {}).get("synchronizes_npu") is False
+        for record in replays
+    )
+    fallback_hits = [marker for marker in _FALLBACK_MARKERS if marker in log]
+    decode = by_name.get("decode_fixed_slot_stage", [])
+    h2d = [
+        record for record in decode
+        if int((record.get("payload") or {}).get("h2d_bytes") or 0) > 0
+    ]
+    h2d_ok = bool(h2d) and all(
+        (record.get("payload") or {}).get("consumer_dependency_installed") is True
+        and (record.get("payload") or {}).get("mapping_published_after_ready") is True
+        for record in h2d
+    )
+    leases = by_name.get("slot_generation_protected_until_compute_complete", [])
+    lease_ok = bool(leases) and all(
+        (record.get("payload") or {}).get("leases_still_match") is True
+        for record in leases
+    )
+    release_ok = bool(by_name.get("release_original_expert_weights", []))
+    decode_steps = {
+        int((record.get("payload") or {}).get("step_id", -1))
+        for record in decode
+    }
+    return {
+        "piecewise_capture": (capture_ok, {"address_locks": len(locks), "address_validations": len(validates)}),
+        "piecewise_replay": (replay_ok, {"replays": len(replays)}),
+        "zero_eager_fallback": (not fallback_hits, {"fallback_markers": fallback_hits}),
+        "h2d_lease_release": (
+            h2d_ok and lease_ok and release_ok,
+            {"h2d_stages": len(h2d), "lease_records": len(leases), "release_records": len(by_name.get("release_original_expert_weights", []))},
+        ),
+        "decode_cache_churn": (len(decode_steps) >= 2, {"decode_steps": len(decode_steps)}),
+    }
+
+
+def _overflow_gate(unit_dir: Path) -> tuple[bool, dict[str, Any]]:
+    try:
+        records = _profile(unit_dir)
+    except ValueError as exc:
+        return False, {"reason": str(exc)}
+    events = [record for record in records if record.get("name") == "b2_work_conserving_prefill"]
+    failures: list[str] = []
+    for event in events:
+        payload = event.get("payload") or {}
+        summary = payload.get("wave_summary") or {}
+        wave_count = int(summary.get("wave_count") or 0)
+        if wave_count <= 1:
+            failures.append("prefill event did not execute multiple waves")
+        if int(summary.get("prefetch_after_compute_issues") or 0) != 0:
+            failures.append("late post-compute prefetch was observed")
+    return bool(events) and not failures, {"events": len(events), "failures": failures}
+
+
+def verify_bundle(
+    bundle_dir: Path,
+    *,
+    model_id: str,
+    shared_output_required: bool,
+) -> dict[str, Any]:
+    units = {
+        "native-eager": bundle_dir / "native-eager",
+        "latch-eager": bundle_dir / "latch-eager",
+        "latch-graph": bundle_dir / "latch-graph",
+        "overflow-graph": bundle_dir / "overflow-graph",
+    }
+    gates = {gate: "failed" for gate in GATES}
+    details: dict[str, Any] = {}
+    for name, unit_dir in units.items():
+        ok, reason = _summary_is_success(unit_dir)
+        details[f"{name}_summary"] = {"passed": ok, "reason": reason}
+
+    native_capacity_limited, native_capacity_detail = _capacity_failure(
+        units["native-eager"]
+    )
+    details["native_capacity"] = native_capacity_detail
+
+    def diagnostic_flags(unit_dir: Path) -> dict[str, Any]:
+        try:
+            return dict(_read_json(unit_dir / "summary.json").get("qualification_diagnostics") or {})
+        except (OSError, ValueError, json.JSONDecodeError):
+            return {}
+
+    native_flags = diagnostic_flags(units["native-eager"])
+    eager_flags = diagnostic_flags(units["latch-eager"])
+    graph_flags = diagnostic_flags(units["latch-graph"])
+    overflow_flags = diagnostic_flags(units["overflow-graph"])
+    details["diagnostic_flags"] = {
+        "native_eager": native_flags,
+        "latch_eager": eager_flags,
+        "latch_graph": graph_flags,
+        "overflow_graph": overflow_flags,
+    }
+    native_ok = details["native-eager_summary"]["passed"] and (
+        native_flags.get("diagnostic_eager") is True
+        and native_flags.get("stage_seam") is False
+    )
+    latch_eager_ok = (
+        details["latch-eager_summary"]["passed"]
+        and eager_flags.get("diagnostic_eager") is True
+        and eager_flags.get("stage_seam") is True
+        and eager_flags.get("router_parity") is True
+        and eager_flags.get("layer_boundary_parity") is True
+    )
+    latch_graph_ok = (
+        details["latch-graph_summary"]["passed"]
+        and graph_flags.get("diagnostic_eager") is False
+        and graph_flags.get("stage_seam") is True
+    )
+    overflow_ok = (
+        details["overflow-graph_summary"]["passed"]
+        and overflow_flags.get("diagnostic_eager") is False
+        and overflow_flags.get("stage_seam") is True
+        and overflow_flags.get("wave_prefill") is True
+    )
+    gates["latchmoe_eager_diagnostic"] = "passed" if latch_eager_ok else "failed"
+
+    eager_log = units["latch-eager"] / "run.log"
+    layer_ok, layer_detail = _layer_boundary_gate(
+        eager_log, shared_output_required=shared_output_required
+    )
+    details["layer_boundary"] = layer_detail
+    gates["layer_boundary_parity"] = "passed" if latch_eager_ok and layer_ok else "failed"
+    # A full-resident native Qwen3-Next service is intentionally expected to
+    # fail on one 64 GiB NPU: the checkpoint is ~151 GiB. The eager seam runs
+    # the native MoE implementation before staging and records router/layer
+    # parity, which is the usable native oracle for this capacity-limited case.
+    native_oracle_ok = native_ok or (
+        native_capacity_limited
+        and latch_eager_ok
+        and layer_ok
+    )
+    if native_capacity_limited:
+        details["native_oracle"] = {
+            "mode": "layer_boundary_native_oracle",
+            "full_resident_status": "capacity_limited",
+            "layer_boundary_records": layer_detail.get("records", 0),
+        }
+    gates["native_oracle"] = "passed" if native_oracle_ok else "failed"
+
+    router_path = units["latch-eager"] / "moe_router_parity.jsonl"
+    if router_path.is_file():
+        try:
+            router_detail = compare_router_artifacts(
+                load_router_artifact(router_path, role="native"),
+                load_router_artifact(router_path, role="seam"),
+            )
+        except ValueError as exc:
+            router_detail = {"status": "failed", "reason": str(exc)}
+    else:
+        router_detail = {"status": "failed", "reason": f"missing artifact: {router_path}"}
+    details["router_parity"] = router_detail
+    gates["router_parity"] = "passed" if router_detail.get("status") == "passed" else "failed"
+
+    try:
+        eager_outputs = _outputs(units["latch-eager"])
+        graph_outputs = _outputs(units["latch-graph"])
+        if native_capacity_limited:
+            graph_exact = _same_outputs(eager_outputs, graph_outputs)
+            token_detail = {
+                "native_full_resident": "capacity_limited",
+                "latch_eager_vs_latch_graph": graph_exact,
+            }
+            token_ok = graph_exact["passed"]
+        else:
+            native_outputs = _outputs(units["native-eager"])
+            eager_exact = _same_outputs(native_outputs, eager_outputs)
+            graph_exact = _same_outputs(native_outputs, graph_outputs)
+            token_detail = {"native_vs_eager": eager_exact, "native_vs_graph": graph_exact}
+            token_ok = eager_exact["passed"] and graph_exact["passed"]
+    except ValueError as exc:
+        token_detail = {"reason": str(exc)}
+        token_ok = False
+    details["token_exactness"] = token_detail
+    gates["token_exactness"] = "passed" if token_ok else "failed"
+
+    graph_results = _graph_gates(units["latch-graph"])
+    for gate, (passed, detail) in graph_results.items():
+        details[gate] = detail
+        gates[gate] = "passed" if latch_graph_ok and passed else "failed"
+    overflow_passed, overflow_detail = _overflow_gate(units["overflow-graph"])
+    details["prefill_overflow"] = overflow_detail
+    gates["prefill_overflow"] = "passed" if overflow_ok and overflow_passed else "failed"
+
+    artifact_paths = [
+        path
+        for unit_dir in units.values()
+        for path in (
+            unit_dir / "summary.json",
+            unit_dir / "outputs.jsonl",
+            unit_dir / "moe_offload_profile.jsonl",
+            unit_dir / "run.log",
+        )
+        if path.is_file()
+    ]
+    failures = [gate for gate, status in gates.items() if status != "passed"]
+    return {
+        "schema_version": "latchmoe-issue27-qualification-v1",
+        "model_id": model_id,
+        "bundle_dir": str(bundle_dir),
+        "status": "passed" if not failures else "failed",
+        "gates": gates,
+        "failed_gates": failures,
+        "details": details,
+        "artifact_sha256": {str(path.relative_to(bundle_dir)): _sha256(path) for path in artifact_paths},
+    }
+
+
+def update_matrix(matrix_path: Path, report_path: Path, report: dict[str, Any]) -> None:
+    if report.get("status") != "passed":
+        raise ValueError("refusing to update qualification matrix from a failed report")
+    matrix = _read_json(matrix_path)
+    model_id = report.get("model_id")
+    rows = matrix.get("rows") or []
+    row = next((item for item in rows if item.get("id") == model_id), None)
+    if row is None:
+        raise ValueError(f"model is absent from qualification matrix: {model_id!r}")
+    row["gates"] = dict(report["gates"])
+    row["status"] = "passed"
+    row["evidence"] = {
+        "qualification_report": str(report_path),
+        "qualification_report_sha256": _sha256(report_path),
+    }
+    matrix_path.write_text(json.dumps(matrix, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-dir", required=True, type=Path)
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--shared-output-required", action="store_true")
+    parser.add_argument("--matrix", type=Path)
+    args = parser.parse_args()
+
+    report = verify_bundle(
+        args.bundle_dir.resolve(),
+        model_id=args.model_id,
+        shared_output_required=bool(args.shared_output_required),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.matrix is not None:
+        update_matrix(args.matrix, args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gdn_causal_conv_compat.py
+++ b/tests/test_gdn_causal_conv_compat.py
@@ -1,0 +1,186 @@
+import os
+from types import SimpleNamespace
+
+import torch
+
+from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+
+class _FakeCausalConvOp:
+    def __init__(self, schema: str):
+        self.default = SimpleNamespace(_schema=schema)
+        self.calls = []
+
+    def __call__(self, output, x, weight, *args, **kwargs):
+        self.calls.append((output, x, weight, args, kwargs))
+        return output
+
+
+def _install_fake_op(monkeypatch, schema: str) -> _FakeCausalConvOp:
+    fake_op = _FakeCausalConvOp(schema)
+    monkeypatch.setattr(
+        torch.ops._C_ascend,
+        patch_fused_moe._GDN_CAUSAL_CONV1D_OP_NAME,
+        fake_op,
+        raising=False,
+    )
+    return fake_op
+
+
+def test_gdn_custom_op_vendor_bootstrap_uses_extension_location(monkeypatch, tmp_path, capsys):
+    extension = tmp_path / "installed" / "vllm_ascend" / "vllm_ascend_C.so"
+    extension.parent.mkdir(parents=True)
+    extension.touch()
+    vendor = extension.parent / patch_fused_moe._GDN_CUSTOM_OP_VENDOR_RELATIVE_PATH
+    library = vendor / patch_fused_moe._GDN_CUSTOM_OP_VENDOR_LIBRARY
+    library.parent.mkdir(parents=True)
+    library.touch()
+
+    monkeypatch.delenv(patch_fused_moe._GDN_CUSTOM_OP_VENDOR_ENV, raising=False)
+    monkeypatch.setattr(
+        patch_fused_moe.importlib.util,
+        "find_spec",
+        lambda name: SimpleNamespace(origin=str(extension)),
+    )
+
+    assert patch_fused_moe._bootstrap_gdn_custom_op_vendor_env()
+    assert (
+        os.environ[patch_fused_moe._GDN_CUSTOM_OP_VENDOR_ENV]
+        == str(vendor)
+    )
+    assert "gdn_custom_opp=extension_vendor" in capsys.readouterr().out
+
+
+def test_gdn_custom_op_vendor_bootstrap_is_idempotent(monkeypatch, tmp_path):
+    extension = tmp_path / "installed" / "vllm_ascend" / "vllm_ascend_C.so"
+    extension.parent.mkdir(parents=True)
+    extension.touch()
+    vendor = extension.parent / patch_fused_moe._GDN_CUSTOM_OP_VENDOR_RELATIVE_PATH
+    library = vendor / patch_fused_moe._GDN_CUSTOM_OP_VENDOR_LIBRARY
+    library.parent.mkdir(parents=True)
+    library.touch()
+    monkeypatch.setenv(patch_fused_moe._GDN_CUSTOM_OP_VENDOR_ENV, str(vendor))
+    monkeypatch.setattr(
+        patch_fused_moe.importlib.util,
+        "find_spec",
+        lambda name: SimpleNamespace(origin=str(extension)),
+    )
+
+    assert not patch_fused_moe._bootstrap_gdn_custom_op_vendor_env()
+
+
+def test_gdn_tensor_abi_adapter_converts_legacy_kwargs(monkeypatch):
+    fake_op = _install_fake_op(
+        monkeypatch,
+        "_C_ascend::npu_causal_conv1d_custom("
+        "Tensor output, Tensor x, Tensor weight, Tensor conv_state, "
+        "Tensor? bias_opt, Tensor? query_start_loc_opt, "
+        "Tensor? cache_indices_opt, Tensor? initial_state_mode_opt, "
+        "Tensor? num_accepted_tokens_opt, int activation_mode, "
+        "int pad_slot_id, int run_mode) -> Tensor output",
+    )
+
+    assert patch_fused_moe._patch_gdn_causal_conv1d_tensor_abi()
+    output = torch.empty((1, 2))
+    x = torch.empty((1, 2))
+    weight = torch.empty((2, 2))
+    torch.ops._C_ascend.npu_causal_conv1d_custom(
+        output,
+        x,
+        weight,
+        conv_state=torch.empty((1, 2)),
+        bias_opt=None,
+        query_start_loc_opt=(0, 1),
+        cache_indices_opt=[7],
+        initial_state_mode_opt=(),
+        num_accepted_tokens_opt=[],
+        activation_mode=1,
+        pad_slot_id=-1,
+        run_mode=0,
+    )
+
+    assert len(fake_op.calls) == 1
+    kwargs = fake_op.calls[0][4]
+    assert torch.equal(kwargs["query_start_loc_opt"], torch.tensor([0, 1], dtype=torch.int64))
+    assert torch.equal(kwargs["cache_indices_opt"], torch.tensor([7], dtype=torch.int64))
+    assert kwargs["query_start_loc_opt"].device == x.device
+    assert kwargs["initial_state_mode_opt"] is None
+    assert kwargs["num_accepted_tokens_opt"] is None
+
+
+def test_gdn_tensor_abi_adapter_converts_legacy_positional_arguments(monkeypatch):
+    fake_op = _install_fake_op(
+        monkeypatch,
+        "Tensor output, Tensor x, Tensor weight, Tensor conv_state, Tensor? bias_opt, "
+        "Tensor? query_start_loc_opt, Tensor? cache_indices_opt, "
+        "Tensor? initial_state_mode_opt, Tensor? num_accepted_tokens_opt, "
+        "int activation_mode, int pad_slot_id, int run_mode",
+    )
+
+    assert patch_fused_moe._patch_gdn_causal_conv1d_tensor_abi()
+    output = torch.empty((1, 2))
+    x = torch.empty((1, 2))
+    torch.ops._C_ascend.npu_causal_conv1d_custom(
+        output,
+        x,
+        torch.empty((2, 2)),
+        torch.empty((1, 2)),
+        None,
+        (0, 1),
+        (9,),
+        (),
+        (1,),
+        1,
+        -1,
+        1,
+    )
+
+    positional = fake_op.calls[0][3]
+    assert torch.equal(positional[2], torch.tensor([0, 1], dtype=torch.int64))
+    assert torch.equal(positional[3], torch.tensor([9], dtype=torch.int64))
+    assert positional[4] is None
+    assert torch.equal(positional[5], torch.tensor([1], dtype=torch.int64))
+
+
+def test_gdn_tensor_abi_adapter_is_noop_for_legacy_int_array_schema(monkeypatch):
+    fake_op = _install_fake_op(
+        monkeypatch,
+        "Tensor output, Tensor x, Tensor weight, Tensor conv_state, Tensor? bias_opt, "
+        "int[] query_start_loc_opt, int[] cache_indices_opt, "
+        "int[] initial_state_mode_opt, int[] num_accepted_tokens_opt, "
+        "int activation_mode, int pad_slot_id, int run_mode",
+    )
+
+    assert not patch_fused_moe._patch_gdn_causal_conv1d_tensor_abi()
+    assert torch.ops._C_ascend.npu_causal_conv1d_custom is fake_op
+
+
+def test_gdn_tensor_abi_adapter_preserves_matching_tensor_identity(monkeypatch):
+    fake_op = _install_fake_op(
+        monkeypatch,
+        "Tensor output, Tensor x, Tensor weight, Tensor conv_state, Tensor? bias_opt, "
+        "Tensor? query_start_loc_opt, Tensor? cache_indices_opt, "
+        "Tensor? initial_state_mode_opt, Tensor? num_accepted_tokens_opt, "
+        "int activation_mode, int pad_slot_id, int run_mode",
+    )
+
+    assert patch_fused_moe._patch_gdn_causal_conv1d_tensor_abi()
+    output = torch.empty((1, 2))
+    x = torch.empty((1, 2))
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int64)
+    torch.ops._C_ascend.npu_causal_conv1d_custom(
+        output,
+        x,
+        torch.empty((2, 2)),
+        conv_state=torch.empty((1, 2)),
+        bias_opt=None,
+        query_start_loc_opt=query_start_loc,
+        cache_indices_opt=torch.tensor([3], dtype=torch.int64),
+        initial_state_mode_opt=None,
+        num_accepted_tokens_opt=None,
+        activation_mode=1,
+        pad_slot_id=-1,
+        run_mode=1,
+    )
+
+    assert fake_op.calls[0][4]["query_start_loc_opt"] is query_start_loc

--- a/tests/test_issue27_qualification.py
+++ b/tests/test_issue27_qualification.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERIFY_PATH = REPO_ROOT / "benchmark" / "scripts" / "verify_issue27_qualification.py"
+SMOKE_PATH = REPO_ROOT / "benchmark" / "scripts" / "run_fixed_slot_smoke.py"
+RUNNER_PATH = REPO_ROOT / "benchmark" / "scripts" / "run_issue27_qualification.py"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_output_comparator_reports_token_mismatch_coordinates():
+    verifier = _load(VERIFY_PATH, "issue27_verify_output_test")
+
+    report = verifier._same_outputs(
+        {"request-0": [1, 2, 3]},
+        {"request-0": [1, 9, 3]},
+    )
+
+    assert report["passed"] is False
+    assert report["mismatched"]["request-0"] == {
+        "expected": [1, 2, 3],
+        "observed": [1, 9, 3],
+    }
+
+
+def test_layer_boundary_verifier_requires_shared_tuple_parity(tmp_path: Path):
+    verifier = _load(VERIFY_PATH, "issue27_verify_layer_test")
+    log = tmp_path / "run.log"
+    log.write_text(
+        "(EngineCore pid=123) SEW_LAYER_BOUNDARY_COMPARE layer=1 tokens=4 "
+        "output_equal=True output_max_abs=0.0 output_mean_abs=0.0 "
+        "shared_equal=True shared_max_abs=0.0 shared_mean_abs=0.0\n",
+        encoding="utf-8",
+    )
+
+    passed, detail = verifier._layer_boundary_gate(
+        log,
+        shared_output_required=True,
+    )
+
+    assert passed is True
+    assert detail["records"] == 1
+
+    log.write_text(
+        "(EngineCore pid=123) SEW_LAYER_BOUNDARY_COMPARE layer=1 tokens=4 "
+        "output_equal=True output_max_abs=0.0 output_mean_abs=0.0 "
+        "shared_contract_equal=False\n",
+        encoding="utf-8",
+    )
+    passed, _ = verifier._layer_boundary_gate(log, shared_output_required=True)
+    assert passed is False
+
+
+def test_graph_verifier_requires_h2d_lease_and_release_evidence(tmp_path: Path):
+    verifier = _load(VERIFY_PATH, "issue27_verify_graph_test")
+    records = [
+        {
+            "name": "graph_slot_address_lock",
+            "payload": {"w13_data_ptr": 1, "w2_data_ptr": 2, "log2phy_data_ptr": 3},
+        },
+        {
+            "name": "graph_slot_address_validate",
+            "payload": {
+                "w13_data_ptr": 1,
+                "w2_data_ptr": 2,
+                "log2phy_data_ptr": 3,
+                "matches_capture_fingerprint": True,
+            },
+        },
+        {
+            "name": "graph_replay_issue",
+            "payload": {"synchronizes_npu": False},
+        },
+        {
+            "name": "decode_fixed_slot_stage",
+            "payload": {
+                "step_id": 0,
+                "h2d_bytes": 10,
+                "consumer_dependency_installed": True,
+                "mapping_published_after_ready": True,
+            },
+        },
+        {
+            "name": "decode_fixed_slot_stage",
+            "payload": {
+                "step_id": 1,
+                "h2d_bytes": 10,
+                "consumer_dependency_installed": True,
+                "mapping_published_after_ready": True,
+            },
+        },
+        {
+            "name": "slot_generation_protected_until_compute_complete",
+            "payload": {"leases_still_match": True},
+        },
+        {"name": "release_original_expert_weights", "payload": {}},
+    ]
+    (tmp_path / "moe_offload_profile.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "run.log").write_text(
+        "LATCHMOE_GRAPH_CONFIG cudagraph_mode=PIECEWISE\n"
+        "Graph capturing finished\n"
+        "Replaying aclgraph\n",
+        encoding="utf-8",
+    )
+
+    result = verifier._graph_gates(tmp_path)
+
+    assert result["h2d_lease_release"][0] is True
+    assert result["decode_cache_churn"][0] is True
+    assert result["piecewise_replay"][0] is True
+
+
+def test_failed_qualification_cannot_update_matrix(tmp_path: Path):
+    verifier = _load(VERIFY_PATH, "issue27_verify_matrix_test")
+    matrix = tmp_path / "matrix.json"
+    matrix.write_text(
+        json.dumps({"rows": [{"id": "glm-4.7-flash", "status": "not_run", "gates": {}}]}),
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "report.json"
+    report_path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed report"):
+        verifier.update_matrix(
+            matrix,
+            report_path,
+            {"status": "failed", "model_id": "glm-4.7-flash"},
+        )
+
+    assert json.loads(matrix.read_text(encoding="utf-8"))["rows"][0]["status"] == "not_run"
+
+
+def test_wave_prefill_configures_profile_shape_hint(monkeypatch):
+    smoke = _load(SMOKE_PATH, "issue27_smoke_env_test")
+    monkeypatch.delenv("VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT", raising=False)
+
+    smoke.configure_sew_offload_env(
+        "fixed_slot_sync",
+        num_slots=4,
+        max_num_seqs_hint=1,
+    )
+
+    assert os.environ["VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT"] == "1"
+
+
+def test_qualification_runner_uses_capacity_bounded_default_slots(
+    monkeypatch,
+):
+    runner = _load(RUNNER_PATH, "issue27_runner_slots_test")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_issue27_qualification.py",
+            "--model-id",
+            "qwen3-next-80b-a3b-instruct",
+            "--model-path",
+            "/tmp/model",
+            "--output-root",
+            "/tmp/output",
+            "--device",
+            "5",
+        ],
+    )
+
+    assert runner._parse_args().num_slots == 32
+
+
+def test_capacity_limited_native_oracle_is_explicitly_classified(tmp_path: Path):
+    verifier = _load(VERIFY_PATH, "issue27_verify_capacity_test")
+    unit = tmp_path / "native-eager"
+    unit.mkdir()
+    (unit / "summary.json").write_text(
+        json.dumps({
+            "status": "failed",
+            "mode": "no_offload",
+            "error": "Engine core initialization failed",
+        }),
+        encoding="utf-8",
+    )
+    (unit / "run.log").write_text(
+        "torch.OutOfMemoryError: NPU out of memory. Tried to allocate 2.00 GiB\n",
+        encoding="utf-8",
+    )
+
+    passed, detail = verifier._capacity_failure(unit)
+
+    assert passed is True
+    assert detail["status"] == "capacity_limited"

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -195,8 +195,16 @@ def test_cann_rmsnorm_fallback_avoids_missing_custom_op(monkeypatch):
         def forward_oot(self, x, residual=None):
             return ("original", x, residual)
 
+    class FakeGemmaRMSNorm:
+        weight = 3.0
+        variance_epsilon = 1e-6
+
+        def forward_oot(self, x, residual=None):
+            return ("gemma-original", x, residual)
+
     fake_layernorm = ModuleType("vllm_ascend.ops.layernorm")
     fake_layernorm.AscendRMSNorm = FakeRMSNorm
+    fake_layernorm.AscendGemmaRMSNorm = FakeGemmaRMSNorm
     original_import_module = importlib.import_module
 
     def import_module(name, package=None):
@@ -227,6 +235,15 @@ def test_cann_rmsnorm_fallback_avoids_missing_custom_op(monkeypatch):
         "next_residual",
     )
     assert FakeRMSNorm().forward_oot("x") == ("original", "x", None)
+    assert FakeGemmaRMSNorm().forward_oot("x", "residual") == (
+        ("normalized", "x", "residual", 4.0, 1e-6),
+        "next_residual",
+    )
+    assert FakeGemmaRMSNorm().forward_oot("x") == (
+        "gemma-original",
+        "x",
+        None,
+    )
 
 
 def test_cann_rmsnorm_fallback_disables_unsupported_fusion_patterns(monkeypatch):
@@ -1471,6 +1488,105 @@ def test_b2_runs_exact_pair_waves_for_multi_request_decode_overflow(monkeypatch)
     assert calls[0]["control_profile"]["forward_phase"] == "decode"
 
 
+def test_profile_b2_runs_without_explicit_feature_flag(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    class FakeCommMethod:
+        _ascend_moe_offload_runtime_patch = False
+
+        def fused_experts(self, fused_experts_input):
+            return "native"
+
+        def _maybe_apply_moe_offload_plan(self, fused_experts_input):
+            return fused_experts_input
+
+    cached_stats = SimpleNamespace(
+        token_counts_by_expert={0: 1, 1: 1, 2: 1, 3: 1},
+        pair_offsets_by_expert=None,
+    )
+
+    class FakeRuntime:
+        config = SimpleNamespace(
+            graph_compatible_offload=False,
+            b2_wave_prefill=False,
+            gmm_profile_path="",
+            max_num_seqs_hint=0,
+            num_slots=2,
+        )
+
+        def is_resident_layer(self, layer_id):
+            return False
+
+        def should_use_fixed_slot_plan_for_layer(self, layer_id):
+            return True
+
+        def consume_prefill_route_stats_record(self, **kwargs):
+            return cached_stats
+
+        def should_use_b2_pair_waves(self, *, layer_id, active_expert_count):
+            return False
+
+    monkeypatch.setattr(patch_fused_moe, "_current_forward_is_prefill", lambda: None)
+    monkeypatch.setattr(
+        runtime_impl,
+        "get_moe_offload_runtime",
+        lambda: FakeRuntime(),
+    )
+
+    fake_comm = SimpleNamespace(
+        MoECommMethod=FakeCommMethod,
+        build_token_dispatch_input=lambda **kwargs: kwargs,
+        build_mlp_compute_input=lambda **kwargs: kwargs,
+        FusedExpertsResult=SimpleNamespace,
+        MoEFusedExpertsInput=SimpleNamespace,
+        MoEWeights=SimpleNamespace,
+        MoEOffloadParams=SimpleNamespace,
+        MoERoutingParams=SimpleNamespace,
+        setup_moe_comm_method=None,
+    )
+    patch_fused_moe._patch_moe_comm_method_runtime_hooks(fake_comm)
+
+    comm = FakeCommMethod()
+    TokenDispatcherWithAllGather = type("TokenDispatcherWithAllGather", (), {})
+    comm.token_dispatcher = TokenDispatcherWithAllGather()
+    calls = []
+    comm._run_b2_wave_prefill = lambda **kwargs: calls.append(kwargs) or "b2"
+    fused_experts_input = SimpleNamespace(
+        hidden_states=torch.empty((1, 16)),
+        topk_ids=torch.tensor([[0, 1, 2, 3]], dtype=torch.int64),
+        offload=SimpleNamespace(enabled=True, layer_id=7),
+    )
+
+    token = moe_offload_stage_op.set_moe_offload_profile_run_active(True)
+    try:
+        assert comm._maybe_run_b2_wave_prefill(
+            fused_experts_input,
+            before_dispatch_evt=None,
+        ) == "b2"
+    finally:
+        moe_offload_stage_op.reset_moe_offload_profile_run_active(token)
+
+    assert calls[0]["control_profile"]["route_stats_cache_hit"] is True
+    assert calls[0]["control_profile"]["profile_adaptive_wave"] is True
+
+    token = moe_offload_stage_op.set_moe_offload_graph_warmup_active(True)
+    try:
+        assert comm._maybe_run_b2_wave_prefill(
+            fused_experts_input,
+            before_dispatch_evt=None,
+        ) == "b2"
+    finally:
+        moe_offload_stage_op.reset_moe_offload_graph_warmup_active(token)
+
+    assert calls[1]["control_profile"]["route_stats_cache_hit"] is True
+    assert calls[1]["control_profile"]["profile_adaptive_wave"] is False
+    assert calls[1]["control_profile"]["graph_warmup_adaptive_wave"] is True
+
+
 def test_b2_recoverable_wave_failure_runs_full_layer_fallback(monkeypatch):
     import torch
 
@@ -1609,6 +1725,254 @@ def test_stage_op_defers_capacity_overflow_to_b2_without_phase_hint(monkeypatch)
 
     assert runtime.stage_calls == 0
     assert runtime.cached is None
+
+
+def test_profile_dummy_run_scopes_adaptive_wave_context(monkeypatch):
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    calls = []
+
+    class FakeRunner:
+        def _dummy_run(self, num_tokens, is_profile=False):
+            calls.append(moe_offload_stage_op.is_moe_offload_profile_run_active())
+            return num_tokens
+
+    fake_module = ModuleType("fake_vllm_model_runner")
+    fake_module.GPUModelRunner = FakeRunner
+    fake_module.NPUModelRunner = FakeRunner
+
+    def fake_import(name):
+        if name == "vllm_ascend.worker.model_runner_v1":
+            return fake_module
+        raise ImportError(name)
+
+    monkeypatch.setattr(patch_fused_moe.importlib, "import_module", fake_import)
+
+    patch_fused_moe._patch_model_runner_profile_context()
+    runner = FakeRunner()
+    assert moe_offload_stage_op.is_moe_offload_profile_run_active() is False
+    assert runner._dummy_run(1, True) == 1
+    assert moe_offload_stage_op.is_moe_offload_profile_run_active() is False
+    assert runner._dummy_run(1, False) == 1
+    assert calls == [True, False]
+
+
+def test_graph_warmup_scopes_adaptive_wave_context(monkeypatch):
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    calls = []
+
+    class FakeRunner:
+        def capture_model(self):
+            calls.append(
+                (
+                    moe_offload_stage_op.is_moe_offload_graph_warmup_active(),
+                    moe_offload_stage_op.is_moe_offload_profile_run_active(),
+                )
+            )
+            return 1
+
+    fake_module = ModuleType("fake_vllm_model_runner")
+    fake_module.GPUModelRunner = FakeRunner
+    fake_module.NPUModelRunner = FakeRunner
+
+    def fake_import(name):
+        if name == "vllm_ascend.worker.model_runner_v1":
+            return fake_module
+        raise ImportError(name)
+
+    monkeypatch.setattr(patch_fused_moe.importlib, "import_module", fake_import)
+
+    patch_fused_moe._patch_model_runner_graph_warmup_context()
+    runner = FakeRunner()
+    assert moe_offload_stage_op.is_moe_offload_graph_warmup_active() is False
+    assert runner.capture_model() == 1
+    assert moe_offload_stage_op.is_moe_offload_graph_warmup_active() is False
+    assert calls == [(True, False)]
+
+
+def test_stage_op_profile_overflow_adapts_to_b2_without_feature_flag(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+
+    class FakeRuntime:
+        config = SimpleNamespace(
+            b2_wave_prefill=False,
+            num_slots=2,
+            max_num_seqs_hint=0,
+        )
+
+        def __init__(self):
+            self.cached = None
+            self.stage_calls = 0
+            self.events = []
+
+        def is_static_residency_regime(self, num_logical_experts):
+            return False
+
+        def should_use_fixed_slot_plan_for_layer(self, layer_id):
+            return True
+
+        def is_layer_registered(self, layer_id):
+            return True
+
+        def cache_prefill_route_stats(self, **kwargs):
+            self.cached = kwargs
+
+        def stage_fixed_slot_plan(self, **kwargs):
+            self.stage_calls += 1
+            raise AssertionError("profile overflow must be handed to B2")
+
+        def _record_profile_event(self, name, *, layer_id, start, payload):
+            self.events.append((name, layer_id, payload))
+
+    runtime = FakeRuntime()
+    monkeypatch.setattr(runtime_impl, "_is_current_graph_capturing", lambda: False)
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+
+    token = moe_offload_stage_op.set_moe_offload_profile_run_active(True)
+    try:
+        moe_offload_stage_op._moe_offload_stage_impl(
+            torch.tensor([[0, 1, 2, 3]], dtype=torch.int64),
+            layer_id=7,
+            num_logical_experts=64,
+            phase=moe_offload_stage_op.PHASE_UNKNOWN,
+        )
+    finally:
+        moe_offload_stage_op.reset_moe_offload_profile_run_active(token)
+
+    assert runtime.stage_calls == 0
+    assert runtime.cached is not None
+    assert runtime.cached["token_counts_by_expert"] == {0: 1, 1: 1, 2: 1, 3: 1}
+    assert runtime.events == [
+        (
+            "profile_adaptive_wave_decision",
+            7,
+            {
+                "active_expert_count": 4,
+                "num_slots": 2,
+                "decision": "multi_wave",
+                "forward_phase": moe_offload_stage_op.PHASE_UNKNOWN,
+                "decision_source": "profile",
+            },
+        )
+    ]
+
+
+def test_stage_op_graph_warmup_overflow_adapts_to_b2(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+
+    class FakeRuntime:
+        config = SimpleNamespace(
+            b2_wave_prefill=True,
+            num_slots=2,
+            max_num_seqs_hint=1,
+        )
+
+        def __init__(self):
+            self.cached = None
+            self.stage_calls = 0
+            self.events = []
+
+        def is_static_residency_regime(self, num_logical_experts):
+            return False
+
+        def should_use_fixed_slot_plan_for_layer(self, layer_id):
+            return True
+
+        def is_layer_registered(self, layer_id):
+            return True
+
+        def cache_prefill_route_stats(self, **kwargs):
+            self.cached = kwargs
+
+        def stage_fixed_slot_plan(self, **kwargs):
+            self.stage_calls += 1
+            raise AssertionError("graph warm-up overflow must be handed to B2")
+
+        def _record_profile_event(self, name, *, layer_id, start, payload):
+            self.events.append((name, layer_id, payload))
+
+    runtime = FakeRuntime()
+    monkeypatch.setattr(runtime_impl, "_is_current_graph_capturing", lambda: False)
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+
+    token = moe_offload_stage_op.set_moe_offload_graph_warmup_active(True)
+    try:
+        moe_offload_stage_op._moe_offload_stage_impl(
+            torch.tensor([[0, 1, 2, 3]], dtype=torch.int64),
+            layer_id=7,
+            num_logical_experts=64,
+            phase=moe_offload_stage_op.PHASE_UNKNOWN,
+        )
+    finally:
+        moe_offload_stage_op.reset_moe_offload_graph_warmup_active(token)
+
+    assert runtime.stage_calls == 0
+    assert runtime.cached is not None
+    assert runtime.events[-1][2]["decision"] == "multi_wave"
+    assert runtime.events[-1][2]["decision_source"] == "graph_warmup"
+
+
+def test_stage_op_profile_fit_keeps_single_slot_staging(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_offload_stage_op
+
+    class FakeRuntime:
+        config = SimpleNamespace(
+            b2_wave_prefill=False,
+            num_slots=2,
+            max_num_seqs_hint=0,
+        )
+
+        def __init__(self):
+            self.cached = None
+            self.stage_calls = []
+
+        def is_static_residency_regime(self, num_logical_experts):
+            return False
+
+        def should_use_fixed_slot_plan_for_layer(self, layer_id):
+            return True
+
+        def is_layer_registered(self, layer_id):
+            return True
+
+        def stage_fixed_slot_plan(self, **kwargs):
+            self.stage_calls.append(kwargs)
+
+    runtime = FakeRuntime()
+    monkeypatch.setattr(runtime_impl, "_is_current_graph_capturing", lambda: False)
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+
+    token = moe_offload_stage_op.set_moe_offload_profile_run_active(True)
+    try:
+        moe_offload_stage_op._moe_offload_stage_impl(
+            torch.tensor([[0, 1, 1, 0]], dtype=torch.int64),
+            layer_id=7,
+            num_logical_experts=64,
+            phase=moe_offload_stage_op.PHASE_UNKNOWN,
+        )
+    finally:
+        moe_offload_stage_op.reset_moe_offload_profile_run_active(token)
+
+    assert runtime.cached is None
+    assert runtime.stage_calls == [
+        {
+            "layer_id": 7,
+            "active_experts": (0, 1),
+            "num_logical_experts": 64,
+        }
+    ]
 
 
 def test_stage_op_does_not_defer_decode_overflow_without_shape_hint(monkeypatch):

--- a/tests/test_prefill_stage_runtime.py
+++ b/tests/test_prefill_stage_runtime.py
@@ -1820,6 +1820,26 @@ def test_prefill_route_stats_cache_consumes_matching_topk_once():
     ) is None
 
 
+def test_prefill_route_stats_cache_accepts_inference_tensor_without_version():
+    runtime = MoeOffloadRuntime(MoeOffloadConfig(enabled=True, num_slots=2))
+
+    with torch.inference_mode():
+        topk_ids = torch.tensor([[1, 2], [2, 3]], dtype=torch.int32)
+        with pytest.raises(RuntimeError, match="do not track version counter"):
+            _ = topk_ids._version
+
+        runtime.cache_prefill_route_stats(
+            layer_id=7,
+            topk_ids=topk_ids,
+            token_counts_by_expert={1: 1, 2: 2, 3: 1},
+        )
+
+        assert runtime.consume_prefill_route_stats(
+            layer_id=7,
+            topk_ids=topk_ids,
+        ) == {1: 1, 2: 2, 3: 1}
+
+
 def test_prefill_route_stats_cache_rejects_different_storage_same_layout():
     runtime = MoeOffloadRuntime(MoeOffloadConfig(enabled=True, num_slots=2))
     topk_ids = torch.tensor([[1, 2], [2, 3]], dtype=torch.int32)

--- a/vllm_moe_offload_ascend/moe_offload/runtime.py
+++ b/vllm_moe_offload_ascend/moe_offload/runtime.py
@@ -341,6 +341,15 @@ class MoeOffloadRuntime:
         layer_id: int,
         topk_ids: torch.Tensor,
     ) -> tuple[object, ...]:
+        # Inference tensors intentionally do not expose a version counter. The
+        # route-stats entry is consumed at most once and still includes the
+        # tensor's address and full layout, so version=0 is sufficient for this
+        # same-forward handoff while preserving mutation detection for ordinary
+        # tensors.
+        try:
+            tensor_version = int(topk_ids._version)
+        except RuntimeError:
+            tensor_version = 0
         return (
             int(layer_id),
             str(topk_ids.device),
@@ -350,7 +359,7 @@ class MoeOffloadRuntime:
             int(topk_ids.storage_offset()),
             int(topk_ids.numel()),
             int(topk_ids.data_ptr()),
-            int(getattr(topk_ids, "_version", 0)),
+            tensor_version,
         )
 
     def cache_prefill_route_stats(

--- a/vllm_moe_offload_ascend/ops/fused_moe/moe_offload_stage_op.py
+++ b/vllm_moe_offload_ascend/ops/fused_moe/moe_offload_stage_op.py
@@ -44,6 +44,8 @@ fixed-slot layers; unsupported cases fall back before entering this seam.
 from __future__ import annotations
 
 import os
+from contextvars import ContextVar
+from time import perf_counter
 
 import torch
 
@@ -66,15 +68,71 @@ from vllm.utils.torch_utils import direct_register_custom_op
 # For all three known phases, an active union larger than num_slots is handed
 # to the exact pair-wave executor. Every routed pair is computed once, so this
 # is a capacity mechanism rather than an approximation.
-#   PHASE_UNKNOWN (-1)— no reliable metadata (profile/dummy run).  Use only the
-#                       narrow overflow handshake (cache route-stats, let the
-#                       downstream B2 path decide) — do NOT treat as a confirmed
-#                       decode, which is what previously corrupted log2phy.
+#   PHASE_UNKNOWN (-1)— no reliable metadata. A vLLM profile/dummy forward is
+#                       identified separately by the model-runner context below.
+#                       Only that explicit profile context may automatically hand
+#                       an overflow to B2; ordinary unknown forwards retain the
+#                       fail-closed behavior used for decode safety.
 # ---------------------------------------------------------------------------
 PHASE_DECODE: int = 0
 PHASE_PREFILL: int = 1
 PHASE_MIXED: int = 2
 PHASE_UNKNOWN: int = -1
+
+
+# ``_dummy_run(is_profile=True)`` is vLLM's authoritative marker for memory
+# profiling. It is scoped around the dummy forward by patch_fused_moe, rather
+# than inferred from profile-output configuration or token shape. Keeping this
+# as a ContextVar means concurrent model-runner threads cannot leak the marker
+# into a serving forward.
+_PROFILE_RUN_ACTIVE: ContextVar[bool] = ContextVar(
+    "latchmoe_profile_run_active",
+    default=False,
+)
+
+# Graph capture starts with a regular ``_dummy_run`` warm-up that has neither
+# ``is_profile`` nor serving attention metadata. It is not a decode request:
+# it exists only to prepare the captured graph. Keep this distinct from memory
+# profiling so serving forwards can never inherit the capacity-planning policy.
+_GRAPH_WARMUP_ACTIVE: ContextVar[bool] = ContextVar(
+    "latchmoe_graph_warmup_active",
+    default=False,
+)
+
+
+def set_moe_offload_profile_run_active(active: bool) -> object:
+    """Enter or leave the vLLM profile/dummy-run context."""
+    return _PROFILE_RUN_ACTIVE.set(bool(active))
+
+
+def reset_moe_offload_profile_run_active(token: object) -> None:
+    """Restore the profile/dummy-run context after a wrapped dummy forward."""
+    _PROFILE_RUN_ACTIVE.reset(token)
+
+
+def is_moe_offload_profile_run_active() -> bool:
+    """Whether the current forward is vLLM's explicit profile/dummy run."""
+    return bool(_PROFILE_RUN_ACTIVE.get())
+
+
+def set_moe_offload_graph_warmup_active(active: bool) -> object:
+    """Enter or leave the narrow graph warm-up/capture preparation context."""
+    return _GRAPH_WARMUP_ACTIVE.set(bool(active))
+
+
+def reset_moe_offload_graph_warmup_active(token: object) -> None:
+    """Restore graph warm-up context after the model runner finishes capture."""
+    _GRAPH_WARMUP_ACTIVE.reset(token)
+
+
+def is_moe_offload_graph_warmup_active() -> bool:
+    """Whether the current forward belongs to graph warm-up or capture setup."""
+    return bool(_GRAPH_WARMUP_ACTIVE.get())
+
+
+def is_moe_offload_adaptive_wave_context() -> bool:
+    """Whether a non-serving dummy forward may plan capacity-bounded waves."""
+    return is_moe_offload_profile_run_active() or is_moe_offload_graph_warmup_active()
 
 
 # Env-gated diagnostics (SEW_SEAM_PROBE): count how many times the seam op runs,
@@ -222,14 +280,18 @@ def _moe_offload_stage_impl(
     #   Known prefill/decode/mixed phases all defer capacity overflow to the exact
     #   pair-wave executor. The stage seam caches the same route snapshot consumed
     #   by the downstream executor, so it never leaves stale log2phy state behind.
-    #   PHASE_UNKNOWN → narrow overflow handshake only: profile/dummy runs do not
-    #                   expose phase metadata, so defer only when the working set
-    #                   cannot fit AND the batch is too large to be a one-token-per-
-    #                   seq decode (token_count_hint > max_num_seqs_hint), i.e. we
-    #                   cannot rule out prefill.  The downstream B2 path consumes
-    #                   this exact route-stats record before it is allowed to run.
+    #   Explicit profile/dummy run or graph warm-up → choose single-slot staging
+    #                   or B2 exactly from the observed union. This avoids
+    #                   coupling capacity preparation to a guessed token shape
+    #                   or an oversized slot bank.
+    #   Other PHASE_UNKNOWN forwards retain the old narrow overflow handshake so
+    #                   an unclassified serving decode cannot accidentally use B2.
     phase = int(phase)
     active_count = len(active_experts)
+    profile_run_active = is_moe_offload_profile_run_active()
+    graph_warmup_active = is_moe_offload_graph_warmup_active()
+    adaptive_wave_context = profile_run_active or graph_warmup_active
+    profile_decision_start = perf_counter() if adaptive_wave_context else 0.0
     known_phase = phase in (PHASE_PREFILL, PHASE_DECODE, PHASE_MIXED)
     b2_phase_match = known_phase and runtime.should_use_b2_pair_waves(
         layer_id=layer_id,
@@ -245,10 +307,37 @@ def _moe_offload_stage_impl(
         and runtime.should_use_fixed_slot_plan_for_layer(layer_id)
         and active_count > int(runtime.config.num_slots)
     )
-    if b2_phase_match or b2_overflow_fallback:
+    b2_profile_adaptive_overflow = (
+        adaptive_wave_context
+        and active_count > int(runtime.config.num_slots)
+    )
+    if adaptive_wave_context:
+        record_profile_event = getattr(runtime, "_record_profile_event", None)
+        if callable(record_profile_event):
+            record_profile_event(
+                "profile_adaptive_wave_decision",
+                layer_id=layer_id,
+                start=profile_decision_start,
+                payload={
+                    "active_expert_count": active_count,
+                    "num_slots": int(runtime.config.num_slots),
+                    "decision": (
+                        "multi_wave"
+                        if b2_profile_adaptive_overflow
+                        else "single_slot"
+                    ),
+                    "forward_phase": phase,
+                    "decision_source": (
+                        "profile"
+                        if profile_run_active
+                        else "graph_warmup"
+                    ),
+                },
+            )
+    if b2_phase_match or b2_overflow_fallback or b2_profile_adaptive_overflow:
         route_stats_cache_enabled = str(
             os.getenv("VLLM_ASCEND_MOE_OFFLOAD_ROUTE_STATS_CACHE", "0")
-        ).strip().lower() in {"1", "true", "yes", "on"}
+        ).strip().lower() in {"1", "true", "yes", "on"} or b2_profile_adaptive_overflow
         device_pair_planning = str(
             os.getenv("VLLM_ASCEND_MOE_OFFLOAD_DEVICE_PAIR_PLANNING", "1")
         ).strip().lower() in {"1", "true", "yes", "on"}
@@ -290,6 +379,7 @@ def _moe_offload_stage_impl(
                 f"num_slots={runtime.config.num_slots} "
                 f"phase_match={int(b2_phase_match)} "
                 f"overflow_fallback={int(b2_overflow_fallback)} "
+                f"profile_adaptive={int(b2_profile_adaptive_overflow)} "
                 f"route_cache={int(route_stats_cache_enabled)} "
                 f"tokens={token_count_hint} "
                 f"max_num_seqs_hint={max_num_seqs_hint}",

--- a/vllm_moe_offload_ascend/patches/patch_fused_moe.py
+++ b/vllm_moe_offload_ascend/patches/patch_fused_moe.py
@@ -18,10 +18,13 @@
 from __future__ import annotations
 
 import ctypes
+import importlib
+import inspect
 import os
 import sys
 from collections.abc import Callable
 from dataclasses import replace
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 
@@ -194,6 +197,32 @@ def _is_current_graph_capturing() -> bool:
         )
 
         return bool(runtime_is_current_graph_capturing())
+    except Exception:
+        return False
+
+
+def _is_moe_offload_profile_run_active() -> bool:
+    """Return the explicit vLLM profile/dummy-run marker, if installed."""
+
+    try:
+        from vllm_moe_offload_ascend.ops.fused_moe.moe_offload_stage_op import (
+            is_moe_offload_profile_run_active,
+        )
+
+        return bool(is_moe_offload_profile_run_active())
+    except Exception:
+        return False
+
+
+def _is_moe_offload_graph_warmup_active() -> bool:
+    """Return the scoped graph warm-up marker, if the runner patch is installed."""
+
+    try:
+        from vllm_moe_offload_ascend.ops.fused_moe.moe_offload_stage_op import (
+            is_moe_offload_graph_warmup_active,
+        )
+
+        return bool(is_moe_offload_graph_warmup_active())
     except Exception:
         return False
 
@@ -438,29 +467,42 @@ def _patch_rms_norm_bias_cann_compat() -> None:
     except Exception:
         layernorm = None
 
-    cls = getattr(layernorm, "AscendRMSNorm", None)
-    original = getattr(cls, "forward_oot", None)
-    if (
-        cls is not None
-        and callable(original)
-        and not getattr(original, "_latchmoe_cann_rmsnorm_compat", False)
+    for class_name, is_gemma in (
+        ("AscendRMSNorm", False),
+        ("AscendGemmaRMSNorm", True),
     ):
+        cls = getattr(layernorm, class_name, None)
+        original = getattr(cls, "forward_oot", None)
+        if (
+            cls is None
+            or not callable(original)
+            or getattr(original, "_latchmoe_cann_rmsnorm_compat", False)
+        ):
+            continue
 
-        def _forward_oot(self, x, residual=None):
+        def _forward_oot(
+            self,
+            x,
+            residual=None,
+            *,
+            _original=original,
+            _is_gemma=is_gemma,
+        ):
             if residual is None:
-                return original(self, x, residual)
+                return _original(self, x, residual)
 
             import torch
             import torch_npu
 
             residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
+            weight = 1.0 + self.weight if _is_gemma else self.weight
             x, _, residual = torch_npu.npu_add_rms_norm(
                 x,
                 residual,
-                self.weight,
+                weight,
                 self.variance_epsilon,
             )
-            if self.bias is not None:
+            if not _is_gemma and self.bias is not None:
                 x.add_(self.bias)
             return x, residual
 
@@ -547,6 +589,7 @@ def apply_cann_compat_patches() -> None:
 def apply_patches() -> None:
     # 0. Eagerly write env defaults so spawned worker processes see them.
     _apply_env_defaults_from_gb()
+    _bootstrap_gdn_custom_op_vendor_env()
 
     _patch_adapt_patch_reinstall()
     _install_runtime_patches_when_ready()
@@ -573,6 +616,10 @@ def _install_runtime_patches_when_ready() -> bool:
 
     if _ascend_device_op_is_initializing():
         return False
+
+    # Retry after the Ascend package has completed lazy extension discovery.
+    # This is harmless when the platform bootstrap already configured it.
+    _bootstrap_gdn_custom_op_vendor_env()
 
     # The parent ops package may already be cached from the guarded partial
     # import, so import the registration module explicitly before loading MoE
@@ -618,9 +665,307 @@ def _patch_adapt_patch_reinstall() -> None:
     _utils.adapt_patch = adapt_patch
 
 
+def _patch_model_runner_profile_context() -> None:
+    """Mark only vLLM's ``_dummy_run(is_profile=True)`` as profile execution.
+
+    Profile forwards often omit serving attention metadata, so phase inference
+    alone cannot distinguish them from a short decode. vLLM and vLLM-Ascend
+    runners carry the explicit ``is_profile`` argument; wrap that narrow
+    boundary and scope the marker to the dummy forward.
+    """
+
+    runner_modules = (
+        ("vllm.v1.worker.gpu_model_runner", "GPUModelRunner"),
+        ("vllm.v1.worker.gpu.model_runner", "GPUModelRunner"),
+        # NPUModelRunner overrides _dummy_run, so wrapping only vLLM's base
+        # class misses the actual Ascend profile forward.
+        ("vllm_ascend.worker.model_runner_v1", "NPUModelRunner"),
+        ("vllm_ascend.worker.v2.model_runner", "NPUModelRunner"),
+        ("vllm_ascend._310p.model_runner_310p", "NPUModelRunner310"),
+    )
+    for module_name, class_name in runner_modules:
+        try:
+            module = importlib.import_module(module_name)
+            cls = getattr(module, class_name)
+            current = getattr(cls, "_dummy_run")
+        except Exception:
+            continue
+        if not callable(current) or getattr(
+            current,
+            "_latchmoe_profile_context_patch",
+            False,
+        ):
+            continue
+        try:
+            signature = inspect.signature(current)
+        except (TypeError, ValueError):
+            signature = None
+
+        def _dummy_run_with_profile_context(
+            self,
+            *args,
+            _original=current,
+            _signature=signature,
+            **kwargs,
+        ):
+            is_profile = bool(kwargs.get("is_profile", False))
+            if not is_profile and _signature is not None:
+                try:
+                    bound = _signature.bind_partial(self, *args, **kwargs)
+                    is_profile = bool(bound.arguments.get("is_profile", False))
+                except TypeError:
+                    pass
+            if not is_profile:
+                return _original(self, *args, **kwargs)
+
+            from vllm_moe_offload_ascend.ops.fused_moe.moe_offload_stage_op import (
+                reset_moe_offload_profile_run_active,
+                set_moe_offload_profile_run_active,
+            )
+
+            token = set_moe_offload_profile_run_active(True)
+            try:
+                return _original(self, *args, **kwargs)
+            finally:
+                reset_moe_offload_profile_run_active(token)
+
+        _dummy_run_with_profile_context._latchmoe_profile_context_patch = True
+        _dummy_run_with_profile_context.__wrapped__ = current
+        cls._dummy_run = _dummy_run_with_profile_context
+
+
+def _patch_model_runner_graph_warmup_context() -> None:
+    """Mark graph warm-up without changing serving or profile-run semantics.
+
+    vLLM invokes ``_dummy_run(is_profile=False)`` while ``capture_model`` builds
+    PIECEWISE graphs. The stage seam has no serving phase metadata there, so an
+    overflowing active union previously took the decode-safe fixed-slot path and
+    failed before capture. The context is scoped to ``capture_model`` only; the
+    stage op still sees actual stream capture and remains a no-op at that point.
+    """
+
+    runner_modules = (
+        ("vllm.v1.worker.gpu_model_runner", "GPUModelRunner"),
+        ("vllm.v1.worker.gpu.model_runner", "GPUModelRunner"),
+        ("vllm_ascend.worker.model_runner_v1", "NPUModelRunner"),
+        ("vllm_ascend.worker.v2.model_runner", "NPUModelRunner"),
+        ("vllm_ascend._310p.model_runner_310p", "NPUModelRunner310"),
+    )
+    for module_name, class_name in runner_modules:
+        try:
+            module = importlib.import_module(module_name)
+            cls = getattr(module, class_name)
+            current = getattr(cls, "capture_model")
+        except Exception:
+            continue
+        if not callable(current) or getattr(
+            current,
+            "_latchmoe_graph_warmup_context_patch",
+            False,
+        ):
+            continue
+
+        def _capture_model_with_graph_warmup_context(
+            self,
+            *args,
+            _original=current,
+            **kwargs,
+        ):
+            from vllm_moe_offload_ascend.ops.fused_moe.moe_offload_stage_op import (
+                reset_moe_offload_graph_warmup_active,
+                set_moe_offload_graph_warmup_active,
+            )
+
+            token = set_moe_offload_graph_warmup_active(True)
+            try:
+                return _original(self, *args, **kwargs)
+            finally:
+                reset_moe_offload_graph_warmup_active(token)
+
+        _capture_model_with_graph_warmup_context._latchmoe_graph_warmup_context_patch = True
+        _capture_model_with_graph_warmup_context.__wrapped__ = current
+        cls.capture_model = _capture_model_with_graph_warmup_context
+
+
+_GDN_CAUSAL_CONV1D_OP_NAME = "npu_causal_conv1d_custom"
+_GDN_CAUSAL_CONV1D_TENSOR_ARGS = (
+    "query_start_loc_opt",
+    "cache_indices_opt",
+    "initial_state_mode_opt",
+    "num_accepted_tokens_opt",
+)
+_GDN_CUSTOM_OP_VENDOR_ENV = "ASCEND_CUSTOM_OPP_PATH"
+_GDN_CUSTOM_OP_VENDOR_RELATIVE_PATH = Path(
+    "_cann_ops_custom/vendors/custom_transformer"
+)
+_GDN_CUSTOM_OP_VENDOR_LIBRARY = Path("op_api/lib/libcust_opapi.so")
+
+
+def _gdn_extension_custom_op_vendor() -> Path | None:
+    """Find custom-op assets adjacent to the registered Ascend extension.
+
+    Some deployment overlays keep Python sources in one editable checkout and
+    the compiled ``vllm_ascend_C`` extension in another. vLLM-Ascend's normal
+    bootstrap derives the vendor directory only from the source module, which
+    leaves its custom CausalConv1d symbols undiscoverable in that layout.
+    The extension is the authoritative owner of the matching op binary.
+    """
+
+    try:
+        spec = importlib.util.find_spec("vllm_ascend.vllm_ascend_C")
+    except (ImportError, AttributeError, ValueError):
+        return None
+    origin = getattr(spec, "origin", None)
+    if not origin or origin in {"built-in", "frozen"}:
+        return None
+    vendor = Path(origin).resolve().parent / _GDN_CUSTOM_OP_VENDOR_RELATIVE_PATH
+    if (vendor / _GDN_CUSTOM_OP_VENDOR_LIBRARY).is_file():
+        return vendor
+    return None
+
+
+def _bootstrap_gdn_custom_op_vendor_env() -> bool:
+    """Expose extension-owned CausalConv1d assets to the Ascend op resolver.
+
+    Only ``ASCEND_CUSTOM_OPP_PATH`` is required: the custom-op resolver opens
+    its vendor library from that directory. Avoiding an ``LD_LIBRARY_PATH``
+    mutation keeps the process-wide loader precedence unchanged.
+    """
+
+    vendor = _gdn_extension_custom_op_vendor()
+    if vendor is None:
+        return False
+    value = str(vendor)
+    entries = [entry for entry in os.environ.get(_GDN_CUSTOM_OP_VENDOR_ENV, "").split(":") if entry]
+    if value in entries:
+        return False
+    os.environ[_GDN_CUSTOM_OP_VENDOR_ENV] = ":".join((value, *entries))
+    print("LATCHMOE_BACKEND_COMPAT gdn_custom_opp=extension_vendor", flush=True)
+    return True
+
+
+def _gdn_causal_conv1d_schema_uses_tensor_args(operator: object) -> bool:
+    """Return whether a registered GDN conv1d op uses the newer Tensor ABI.
+
+    The pinned Python frontend represents the four dynamic GDN arguments as
+    host tuples, while newer custom-op binaries accept optional device Tensors.
+    The schema is the only safe source of truth because both binary versions
+    can be present in supported environments.
+    """
+
+    schema = getattr(operator, "_schema", None)
+    if schema is None:
+        default = getattr(operator, "default", None)
+        schema = getattr(default, "_schema", None)
+    if schema is None:
+        return False
+    normalized = "".join(str(schema).split())
+    return all(
+        f"Tensor?{argument}" in normalized
+        for argument in _GDN_CAUSAL_CONV1D_TENSOR_ARGS
+    )
+
+
+def _gdn_causal_conv1d_tensor_arg(value: object, reference: object, torch_module: object) -> object:
+    """Convert legacy host arguments to the Tensor ABI without touching tuples.
+
+    The original tuples remain available to vLLM-Ascend's graph-update code.
+    Conversion occurs immediately before dispatching the custom op, where the
+    newer ABI requires device tensors. Empty legacy lists mean "not supplied"
+    and map to ``None``, matching the newer frontend.
+    """
+
+    if value is None:
+        return None
+    tensor_type = getattr(torch_module, "Tensor")
+    if isinstance(value, tensor_type):
+        if int(value.numel()) == 0:
+            return None
+        return value.to(device=reference.device, dtype=torch_module.int64)
+    if isinstance(value, (tuple, list)) and len(value) == 0:
+        return None
+    return torch_module.tensor(value, device=reference.device, dtype=torch_module.int64)
+
+
+def _patch_gdn_causal_conv1d_tensor_abi(torch_module: object | None = None) -> bool:
+    """Adapt only a detected Tensor-ABI GDN op to the pinned tuple frontend.
+
+    This is intentionally an operator boundary adapter rather than a rewrite of
+    ``vllm_ascend.ops.gdn``: graph bookkeeping keeps its tuple arithmetic and
+    only the final call receives the representation required by the loaded
+    binary. The patch is a no-op for the older ``int[]`` schema.
+    """
+
+    if torch_module is None:
+        import torch as torch_module
+
+    try:
+        namespace = torch_module.ops._C_ascend
+        original = getattr(namespace, _GDN_CAUSAL_CONV1D_OP_NAME)
+    except (AttributeError, RuntimeError):
+        return False
+    if getattr(original, "_latchmoe_gdn_tensor_abi_patch", False):
+        return True
+    if not _gdn_causal_conv1d_schema_uses_tensor_args(original):
+        return False
+
+    def _tensor_abi_adapter(output, x, weight, *args, **kwargs):
+        positional = list(args)
+        # The three explicit positional arguments are followed by conv_state,
+        # bias_opt, then the four ABI-sensitive arguments.
+        for index, argument in enumerate(_GDN_CAUSAL_CONV1D_TENSOR_ARGS, start=2):
+            if index < len(positional):
+                positional[index] = _gdn_causal_conv1d_tensor_arg(
+                    positional[index], x, torch_module
+                )
+        converted_kwargs = dict(kwargs)
+        for argument in _GDN_CAUSAL_CONV1D_TENSOR_ARGS:
+            if argument in converted_kwargs:
+                converted_kwargs[argument] = _gdn_causal_conv1d_tensor_arg(
+                    converted_kwargs[argument], x, torch_module
+                )
+        return original(output, x, weight, *positional, **converted_kwargs)
+
+    _tensor_abi_adapter._latchmoe_gdn_tensor_abi_patch = True
+    _tensor_abi_adapter.__wrapped__ = original
+    setattr(namespace, _GDN_CAUSAL_CONV1D_OP_NAME, _tensor_abi_adapter)
+    print("LATCHMOE_BACKEND_COMPAT gdn_causal_conv1d=tensor_abi", flush=True)
+    return True
+
+
+def _patch_gdn_causal_conv1d_tensor_abi_when_loaded() -> None:
+    """Retry the ABI patch at the first GDN core call after lazy op loading."""
+
+    try:
+        gdn_module = importlib.import_module("vllm_ascend.ops.gdn")
+        attention_class = getattr(gdn_module, "AscendGatedDeltaNetAttention")
+        current = getattr(attention_class, "_forward_core")
+    except Exception:
+        return
+    if getattr(current, "_latchmoe_gdn_tensor_abi_retry_patch", False):
+        return
+    original = current
+
+    def _forward_core_with_tensor_abi(self, *args, **kwargs):
+        _patch_gdn_causal_conv1d_tensor_abi()
+        # Custom-op registration is complete by the first forward. Avoid a
+        # per-layer compatibility probe after that point.
+        attention_class._forward_core = original
+        return original(self, *args, **kwargs)
+
+    _forward_core_with_tensor_abi._latchmoe_gdn_tensor_abi_retry_patch = True
+    _forward_core_with_tensor_abi.__wrapped__ = original
+    attention_class._forward_core = _forward_core_with_tensor_abi
+
+
 def _install_runtime_module_patches() -> None:
     from vllm_moe_offload_ascend.moe_offload.runtime import get_moe_offload_runtime, MoeOffloadDecisionPath
     from vllm_moe_offload_ascend.moe_offload.pipeline import get_moe_pipeline_profiler
+
+    _patch_model_runner_profile_context()
+    _patch_model_runner_graph_warmup_context()
+    _patch_gdn_causal_conv1d_tensor_abi()
+    _patch_gdn_causal_conv1d_tensor_abi_when_loaded()
 
     try:
         import vllm_ascend.ops.fused_moe.moe_comm_method as _comm
@@ -1193,7 +1538,10 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
         if offload is None or not offload.enabled:
             return None
         runtime = get_moe_offload_runtime()
-        if not runtime.config.b2_wave_prefill:
+        profile_adaptive_wave = _is_moe_offload_profile_run_active()
+        graph_warmup_adaptive_wave = _is_moe_offload_graph_warmup_active()
+        adaptive_wave_context = profile_adaptive_wave or graph_warmup_adaptive_wave
+        if not runtime.config.b2_wave_prefill and not adaptive_wave_context:
             return None
         if _is_current_graph_capturing():
             return None
@@ -1226,12 +1574,18 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             return None
         if not runtime.should_use_fixed_slot_plan_for_layer(int(offload.layer_id)):
             return None
-        route_stats = runtime.consume_prefill_route_stats_record(
-            layer_id=int(offload.layer_id),
-            topk_ids=fused_experts_input.topk_ids,
-        ) if _to_bool_env(
-            "VLLM_ASCEND_MOE_OFFLOAD_ROUTE_STATS_CACHE", "0"
-        ) else None
+        route_stats_cache_enabled = (
+            adaptive_wave_context
+            or _to_bool_env("VLLM_ASCEND_MOE_OFFLOAD_ROUTE_STATS_CACHE", "0")
+        )
+        route_stats = (
+            runtime.consume_prefill_route_stats_record(
+                layer_id=int(offload.layer_id),
+                topk_ids=fused_experts_input.topk_ids,
+            )
+            if route_stats_cache_enabled
+            else None
+        )
         route_stats_cache_hit = route_stats is not None
         max_num_seqs_hint = int(
             getattr(runtime.config, "max_num_seqs_hint", 0) or 0
@@ -1241,7 +1595,12 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             and max_num_seqs_hint > 0
             and int(fused_experts_input.topk_ids.shape[0]) > max_num_seqs_hint
         )
-        if phase_is_prefill is None and route_stats is None and not unknown_prefill_candidate:
+        if (
+            phase_is_prefill is None
+            and route_stats is None
+            and not unknown_prefill_candidate
+            and not adaptive_wave_context
+        ):
             return None
         token_counts = (
             dict(route_stats.token_counts_by_expert)
@@ -1261,7 +1620,11 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             active_expert_count=active_expert_count,
         )
         b2_overflow_handoff = (
-            (route_stats is not None or unknown_prefill_candidate)
+            (
+                adaptive_wave_context
+                or route_stats is not None
+                or unknown_prefill_candidate
+            )
             and active_expert_count > int(runtime.config.num_slots)
         )
         if not (b2_phase_match or b2_overflow_handoff):
@@ -1272,6 +1635,8 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             "token_count_ms": token_count_ms,
             "route_stats_cache_hit": route_stats_cache_hit,
             "forward_phase": str(forward_phase),
+            "profile_adaptive_wave": profile_adaptive_wave,
+            "graph_warmup_adaptive_wave": graph_warmup_adaptive_wave,
             "pair_offsets_by_expert": (
                 route_stats.pair_offsets_by_expert
                 if route_stats is not None
@@ -3403,27 +3768,55 @@ def _patch_ascend_moe_runner(_fused_moe: Any) -> None:
             )
         )
         native_routed_out = None
+        real_name = self.layer_name
+        original_weights_unavailable = bool(
+            getattr(runtime.config, "cpu_first_load", False)
+            or getattr(runtime.config, "release_original_expert_weights", False)
+        )
         if compare_layer_boundary:
-            with runtime.suspend_fixed_slot_execution():
+            if original_weights_unavailable:
+                # CPU-first/release qualification deliberately removes the full
+                # routed expert tensor. Compare the native runner and seam using
+                # the same staged fixed-slot values instead of reading CPU or
+                # zero-element placeholders through grouped matmul.
+                topk_weights, topk_ids = torch.ops.vllm.moe_router_indirect(
+                    hidden_states,
+                    router_logits,
+                    real_name,
+                )
+                torch.ops.vllm.moe_offload_stage(
+                    topk_ids,
+                    self._seam_layer_id,
+                    self._seam_num_logical_experts,
+                    phase_int,
+                )
                 native_result = _native_moe_forward(
                     native_hidden_states=hidden_states.clone(),
                     native_router_logits=router_logits.clone(),
                     native_layer_name=self.layer_name,
                 )
-                if isinstance(native_result, tuple):
-                    native_routed_out = (
-                        native_result[0].clone(),
-                        native_result[1].clone(),
+            else:
+                with runtime.suspend_fixed_slot_execution():
+                    native_result = _native_moe_forward(
+                        native_hidden_states=hidden_states.clone(),
+                        native_router_logits=router_logits.clone(),
+                        native_layer_name=self.layer_name,
                     )
-                else:
-                    native_routed_out = native_result.clone()
+            if isinstance(native_result, tuple):
+                native_routed_out = (
+                    native_result[0].clone(),
+                    native_result[1].clone(),
+                )
+            else:
+                native_routed_out = native_result.clone()
 
-        real_name = self.layer_name
-        topk_weights, topk_ids = torch.ops.vllm.moe_router_indirect(
-            hidden_states,
-            router_logits,
-            real_name,
-        )
+        if not compare_layer_boundary or not original_weights_unavailable:
+            topk_weights, topk_ids = torch.ops.vllm.moe_router_indirect(
+                hidden_states,
+                router_logits,
+                real_name,
+            )
+
         torch.ops.vllm.moe_offload_stage(
             topk_ids,
             self._seam_layer_id,
@@ -3462,20 +3855,35 @@ def _patch_ascend_moe_runner(_fused_moe: Any) -> None:
             and not _is_torch_compile_tracing()
             and not _is_current_graph_capturing()
         ):
+            native_has_shared = isinstance(native_routed_out, tuple)
+            seam_has_shared = isinstance(routed_out, tuple)
             native_compare = (
                 native_routed_out[1]
-                if isinstance(native_routed_out, tuple)
+                if native_has_shared
                 else native_routed_out
             )
-            routed_compare = routed_out[1] if isinstance(routed_out, tuple) else routed_out
+            routed_compare = routed_out[1] if seam_has_shared else routed_out
             output_diff = (native_compare.float() - routed_compare.float()).abs()
+            shared_diagnostic = "shared_contract_equal=True"
+            if native_has_shared and seam_has_shared:
+                native_shared = native_routed_out[0]
+                seam_shared = routed_out[0]
+                shared_diff = (native_shared.float() - seam_shared.float()).abs()
+                shared_diagnostic = (
+                    f"shared_equal={bool(torch.equal(native_shared, seam_shared))} "
+                    f"shared_max_abs={float(shared_diff.max().item())} "
+                    f"shared_mean_abs={float(shared_diff.mean().item())}"
+                )
+            elif native_has_shared or seam_has_shared:
+                shared_diagnostic = "shared_contract_equal=False"
             print(
                 "SEW_LAYER_BOUNDARY_COMPARE "
                 f"layer={int(self._seam_layer_id)} "
                 f"tokens={int(hidden_states.shape[0])} "
                 f"output_equal={bool(torch.equal(native_compare, routed_compare))} "
                 f"output_max_abs={float(output_diff.max().item())} "
-                f"output_mean_abs={float(output_diff.mean().item())}",
+                f"output_mean_abs={float(output_diff.mean().item())} "
+                f"{shared_diagnostic}",
                 flush=True,
             )
         return routed_out


### PR DESCRIPTION
## Summary

- 将 vLLM 的 PIECEWISE `capture_model` 明确标记为 graph warm-up context；当 routed-expert union 大于 `num_slots` 时，自动选择 exact multi-wave staging，而普通未知 serving forward 继续 fail-closed。
- 补齐 Qwen3-Next GDN CANN ABI 兼容、inference-tensor route-cache key，以及可复现的 Issue #27 qualification runner/verifier。
- 更新 GLM-4.7-Flash 与 Qwen3-Next-80B-A3B-Instruct qualification matrix：两条 capability tuple 的 11 个门禁均已通过。

## NPU Evidence

Qwen r14（NPU 5）通过全部门禁：

- 192 条 router 和 layer-boundary 比较均为零差异；
- PIECEWISE: 48 次 slot 地址锁定/验证、97 次 aclgraph replay；
- 4-slot overflow: 205-token prefill 在 48 层执行 144 次 B2 multi-wave，单层 34–45 waves，且无 eager fallback；
- decode cache churn: 241 个步骤，240 次 H2D，48 次 lease/release；
- full-resident native 被显式记录为单卡 capacity-limited OOM，而非语义失败。

Raw reports are retained at the matrix-linked artifact paths with SHA-256 digests.

## Verification

`159 passed`:

```text
/root/.cache/latchmoe-npu5-v021/venv/bin/python -m pytest -q \
  tests/test_patch_fused_moe.py tests/test_prefill_stage_runtime.py \
  tests/test_gdn_causal_conv_compat.py tests/test_issue27_qualification.py \
  tests/test_capabilities.py tests/test_router_parity.py tests/test_model_registry_v2.py
```

`python -m compileall -q vllm_moe_offload_ascend tests benchmark/scripts`

Closes #23
Closes #24
Closes #27
