### PR TITLE
fix: preserve fused shared router lanes

### DIFF
--- a/benchmark/scripts/run_fixed_slot_smoke.py
+++ b/benchmark/scripts/run_fixed_slot_smoke.py
@@ -569,6 +569,9 @@ def run_smoke(
                     getattr(args, "layer_boundary_parity", False)
                 ),
                 "wave_prefill": bool(getattr(args, "wave_prefill", False)),
+                "ascend_additional_config": llm_kwargs.get(
+                    "additional_config", {}
+                ),
             },
         }
     )

--- a/benchmark/scripts/run_fixed_slot_smoke.py
+++ b/benchmark/scripts/run_fixed_slot_smoke.py
@@ -90,6 +90,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--kv-cache-memory-mb", type=int, default=512)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.90)
     parser.add_argument(
+        "--ascend-additional-config-json",
+        default="{}",
+        help=(
+            "JSON object forwarded as vLLM-Ascend additional_config and recorded "
+            "in the smoke summary, for example '{\"mix_placement\": true}'."
+        ),
+    )
+    parser.add_argument(
         "--disable-ascend-norm-quant-fusion",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -163,6 +171,14 @@ def parse_args() -> argparse.Namespace:
         parser.error("--layer-boundary-parity requires an eager fixed-slot seam diagnostic")
     if args.wave_prefill and not args.stage_seam:
         parser.error("--wave-prefill requires --stage-seam")
+    try:
+        args.ascend_additional_config = json.loads(
+            args.ascend_additional_config_json
+        )
+    except json.JSONDecodeError as exc:
+        parser.error(f"--ascend-additional-config-json is not valid JSON: {exc.msg}")
+    if not isinstance(args.ascend_additional_config, dict):
+        parser.error("--ascend-additional-config-json must decode to a JSON object")
     return args
 
 
@@ -422,13 +438,16 @@ def _build_llm_kwargs(args: argparse.Namespace, config: dict[str, Any], mode: st
                 "offload_params": _csv_set(args.offload_params),
             }
         )
-    disable_norm_quant = bool(
-        getattr(args, "disable_ascend_norm_quant_fusion", False)
-    )
+    additional_config = dict(getattr(args, "ascend_additional_config", {}) or {})
+    disable_norm_quant = bool(getattr(args, "disable_ascend_norm_quant_fusion", False))
     if disable_norm_quant:
-        kwargs["additional_config"] = {
-            "ascend_compilation_config": {"fuse_norm_quant": False}
-        }
+        compile_config = dict(
+            additional_config.get("ascend_compilation_config") or {}
+        )
+        compile_config["fuse_norm_quant"] = False
+        additional_config["ascend_compilation_config"] = compile_config
+    if additional_config:
+        kwargs["additional_config"] = additional_config
     compilation_config = _smoke_compilation_config(
         mode=mode,
         enforce_eager=bool(args.enforce_eager),
@@ -525,6 +544,7 @@ def run_smoke(
             "disable_ascend_norm_quant_fusion": bool(
                 getattr(args, "disable_ascend_norm_quant_fusion", False)
             ),
+            "ascend_additional_config": llm_kwargs.get("additional_config", {}),
             "load_seconds": load_s,
             "manifest": str(args.manifest),
             "buckets": args.buckets,

--- a/benchmark/scripts/run_issue27_qualification.py
+++ b/benchmark/scripts/run_issue27_qualification.py
@@ -101,6 +101,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--kv-cache-memory-mb", type=int, default=128)
     parser.add_argument("--gpu-memory-utilization", type=float, default=0.96)
     parser.add_argument(
+        "--ascend-additional-config-json",
+        default="{}",
+        help=(
+            "JSON object passed to every smoke unit as vLLM-Ascend "
+            "additional_config, for example '{\"mix_placement\": true}'."
+        ),
+    )
+    parser.add_argument(
         "--prompt",
         default="Hi",
     )
@@ -113,7 +121,19 @@ def _parse_args() -> argparse.Namespace:
             + "The routed expert workload must remain deterministic. " * 24
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    try:
+        args.ascend_additional_config = json.loads(
+            args.ascend_additional_config_json
+        )
+    except json.JSONDecodeError as exc:
+        parser.error(
+            "--ascend-additional-config-json is not valid JSON: "
+            f"{exc.msg}"
+        )
+    if not isinstance(args.ascend_additional_config, dict):
+        parser.error("--ascend-additional-config-json must decode to a JSON object")
+    return args
 
 
 def _base_command(args: argparse.Namespace, unit_dir: Path, *, mode: str, prompt: str, output_tokens: int, slots: int) -> list[str]:
@@ -142,6 +162,8 @@ def _base_command(args: argparse.Namespace, unit_dir: Path, *, mode: str, prompt
         str(int(slots)),
         "--ignore-eos",
         "--disable-ascend-norm-quant-fusion",
+        "--ascend-additional-config-json",
+        json.dumps(args.ascend_additional_config, sort_keys=True),
     ]
     return command
 
@@ -211,6 +233,7 @@ def _run_unit(
                     "router_parity": router_parity,
                     "layer_boundary_parity": layer_boundary_parity,
                     "wave_prefill": wave_prefill,
+                    "ascend_additional_config": args.ascend_additional_config,
                 },
                 "environment": {
                     key: env.get(key)

--- a/benchmark/scripts/verify_issue27_qualification.py
+++ b/benchmark/scripts/verify_issue27_qualification.py
@@ -249,11 +249,100 @@ def _overflow_gate(unit_dir: Path) -> tuple[bool, dict[str, Any]]:
     return bool(events) and not failures, {"events": len(events), "failures": failures}
 
 
+def _fused_shared_lane_gate(
+    unit_dir: Path,
+    *,
+    expected_routed_experts: int,
+    expected_shared_experts: int,
+) -> tuple[bool, dict[str, Any]]:
+    """Verify that every fixed-slot MoE layer registered one pinned suffix."""
+
+    try:
+        records = _profile(unit_dir)
+    except ValueError as exc:
+        return False, {"reason": str(exc)}
+    expected_ids = list(
+        range(
+            int(expected_routed_experts),
+            int(expected_routed_experts) + int(expected_shared_experts),
+        )
+    )
+    registrations = [
+        record for record in records
+        if record.get("name") == "register_layer_for_fixed_slots"
+    ]
+    failures: list[dict[str, Any]] = []
+    for record in registrations:
+        payload = record.get("payload") or {}
+        actual = {
+            "routed_expert_count": int(payload.get("routed_expert_count") or 0),
+            "pinned_shared_expert_count": int(
+                payload.get("pinned_shared_expert_count") or 0
+            ),
+            "pinned_shared_logical_ids": list(
+                payload.get("pinned_shared_logical_ids") or []
+            ),
+        }
+        expected = {
+            "routed_expert_count": int(expected_routed_experts),
+            "pinned_shared_expert_count": int(expected_shared_experts),
+            "pinned_shared_logical_ids": expected_ids,
+        }
+        if actual != expected:
+            failures.append(
+                {
+                    "layer_id": record.get("layer_id"),
+                    "expected": expected,
+                    "actual": actual,
+                }
+            )
+    return bool(registrations) and not failures, {
+        "registrations": len(registrations),
+        "expected": {
+            "routed_expert_count": int(expected_routed_experts),
+            "pinned_shared_expert_count": int(expected_shared_experts),
+            "pinned_shared_logical_ids": expected_ids,
+        },
+        "failures": failures[:8],
+    }
+
+
+def _fused_shared_once_gate(unit_dir: Path) -> tuple[bool, dict[str, Any]]:
+    """Verify that B2 overflow executes each fused shared suffix once."""
+
+    try:
+        records = _profile(unit_dir)
+    except ValueError as exc:
+        return False, {"reason": str(exc)}
+    events = [
+        record for record in records
+        if record.get("name") == "fused_shared_b2_once"
+    ]
+    failures: list[dict[str, Any]] = []
+    for record in events:
+        payload = record.get("payload") or {}
+        if (
+            int(payload.get("shared_pair_execution_count") or 0) != 1
+            or int(payload.get("shared_pairs") or 0) <= 0
+            or int(payload.get("routed_pairs") or 0) <= 0
+        ):
+            failures.append(
+                {"layer_id": record.get("layer_id"), "payload": payload}
+            )
+    return bool(events) and not failures, {
+        "events": len(events),
+        "failures": failures[:8],
+    }
+
+
 def verify_bundle(
     bundle_dir: Path,
     *,
     model_id: str,
     shared_output_required: bool,
+    fused_shared_required: bool = False,
+    expected_routed_experts: int = 0,
+    expected_shared_experts: int = 0,
 ) -> dict[str, Any]:
     units = {
         "native-eager": bundle_dir / "native-eager",
@@ -379,6 +468,49 @@ def verify_bundle(
     details["prefill_overflow"] = overflow_detail
     gates["prefill_overflow"] = "passed" if overflow_ok and overflow_passed else "failed"
 
+    fused_failures: list[str] = []
+    if fused_shared_required:
+        required_config_units = {
+            "native-eager": native_flags,
+            "latch-eager": eager_flags,
+            "latch-graph": graph_flags,
+            "overflow-graph": overflow_flags,
+        }
+        config_failures = {
+            name: flags.get("ascend_additional_config")
+            for name, flags in required_config_units.items()
+            if (flags.get("ascend_additional_config") or {}).get("mix_placement")
+            is not True
+        }
+        details["fused_mix_placement_config"] = {
+            "passed": not config_failures,
+            "failures": config_failures,
+        }
+        if config_failures:
+            fused_failures.append("fused_mix_placement_config")
+
+        lane_units = {
+            "latch-eager": units["latch-eager"],
+            "latch-graph": units["latch-graph"],
+            "overflow-graph": units["overflow-graph"],
+        }
+        lane_details: dict[str, dict[str, Any]] = {}
+        for name, unit_dir in lane_units.items():
+            passed, detail = _fused_shared_lane_gate(
+                unit_dir,
+                expected_routed_experts=expected_routed_experts,
+                expected_shared_experts=expected_shared_experts,
+            )
+            lane_details[name] = {"passed": passed, **detail}
+        details["fused_shared_lane"] = lane_details
+        if not all(detail["passed"] for detail in lane_details.values()):
+            fused_failures.append("fused_shared_lane")
+
+        once_passed, once_detail = _fused_shared_once_gate(units["overflow-graph"])
+        details["fused_shared_once"] = once_detail
+        if not once_passed:
+            fused_failures.append("fused_shared_once")
+
     artifact_paths = [
         path
         for unit_dir in units.values()
@@ -391,6 +523,7 @@ def verify_bundle(
         if path.is_file()
     ]
     failures = [gate for gate, status in gates.items() if status != "passed"]
+    failures.extend(fused_failures)
     return {
         "schema_version": "latchmoe-issue27-qualification-v1",
         "model_id": model_id,
@@ -427,13 +560,26 @@ def main() -> int:
     parser.add_argument("--model-id", required=True)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--shared-output-required", action="store_true")
+    parser.add_argument("--fused-shared-required", action="store_true")
+    parser.add_argument("--expected-routed-experts", type=int, default=0)
+    parser.add_argument("--expected-shared-experts", type=int, default=0)
     parser.add_argument("--matrix", type=Path)
     args = parser.parse_args()
+    if args.fused_shared_required and (
+        args.expected_routed_experts <= 0 or args.expected_shared_experts <= 0
+    ):
+        parser.error(
+            "--fused-shared-required requires positive --expected-routed-experts "
+            "and --expected-shared-experts"
+        )
 
     report = verify_bundle(
         args.bundle_dir.resolve(),
         model_id=args.model_id,
         shared_output_required=bool(args.shared_output_required),
+        fused_shared_required=bool(args.fused_shared_required),
+        expected_routed_experts=int(args.expected_routed_experts),
+        expected_shared_experts=int(args.expected_shared_experts),
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -89,14 +89,47 @@ def test_internal_router_and_gated_shared_do_not_depend_on_model_name():
 
 def test_fused_mix_placement_is_described_and_supported_by_its_own_lane():
     descriptor = describe_layer_capability(
-        _layer(n_shared_experts=2, mix_placement=True),
+        _layer(
+            n_shared_experts=2,
+            mix_placement=True,
+            moe_config=SimpleNamespace(
+                # FusedMoE materializes routed + shared rows, while retaining
+                # num_logical_experts as the routed-domain contract.
+                num_experts=66,
+                num_logical_experts=64,
+                dp_size=1,
+                ep_size=1,
+                tp_size=1,
+                pcp_size=1,
+            ),
+        ),
         _runner(),
     )
     support = evaluate_support(descriptor)
 
     assert descriptor.shared_mode == "fused_mix_placement"
+    assert descriptor.routed_expert_count == 64
     assert support.state == "implemented"
     assert support.blockers == ()
+
+
+def test_fused_mix_placement_derives_routed_count_from_materialized_suffix():
+    descriptor = describe_layer_capability(
+        _layer(
+            n_shared_experts=2,
+            mix_placement=True,
+            moe_config=SimpleNamespace(
+                num_experts=66,
+                dp_size=1,
+                ep_size=1,
+                tp_size=1,
+                pcp_size=1,
+            ),
+        ),
+        _runner(),
+    )
+
+    assert descriptor.routed_expert_count == 64
 
 
 def test_python_router_callable_and_multicard_are_fail_closed():

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -87,7 +87,7 @@ def test_internal_router_and_gated_shared_do_not_depend_on_model_name():
     assert evaluate_support(descriptor).state == "implemented"
 
 
-def test_fused_mix_placement_is_described_but_fail_closed():
+def test_fused_mix_placement_is_described_and_supported_by_its_own_lane():
     descriptor = describe_layer_capability(
         _layer(n_shared_experts=2, mix_placement=True),
         _runner(),
@@ -95,8 +95,8 @@ def test_fused_mix_placement_is_described_but_fail_closed():
     support = evaluate_support(descriptor)
 
     assert descriptor.shared_mode == "fused_mix_placement"
-    assert support.state == "unsupported"
-    assert "unsupported_shared_mode:fused_mix_placement" in support.blockers
+    assert support.state == "implemented"
+    assert support.blockers == ()
 
 
 def test_python_router_callable_and_multicard_are_fail_closed():

--- a/tests/test_issue27_qualification.py
+++ b/tests/test_issue27_qualification.py
@@ -161,6 +161,63 @@ def test_wave_prefill_configures_profile_shape_hint(monkeypatch):
     assert os.environ["VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT"] == "1"
 
 
+def test_fused_shared_verifier_requires_pinned_layout_and_once_event(
+    tmp_path: Path,
+):
+    verifier = _load(VERIFY_PATH, "issue25_verify_fused_test")
+    unit = tmp_path / "overflow-graph"
+    unit.mkdir()
+    records = [
+        {
+            "name": "register_layer_for_fixed_slots",
+            "layer_id": 3,
+            "payload": {
+                "routed_expert_count": 64,
+                "pinned_shared_expert_count": 2,
+                "pinned_shared_logical_ids": [64, 65],
+            },
+        },
+        {
+            "name": "fused_shared_b2_once",
+            "layer_id": 3,
+            "payload": {
+                "shared_pair_execution_count": 1,
+                "shared_pairs": 8,
+                "routed_pairs": 24,
+            },
+        },
+    ]
+    (unit / "moe_offload_profile.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    lane_passed, lane_detail = verifier._fused_shared_lane_gate(
+        unit,
+        expected_routed_experts=64,
+        expected_shared_experts=2,
+    )
+    once_passed, once_detail = verifier._fused_shared_once_gate(unit)
+
+    assert lane_passed is True
+    assert lane_detail["registrations"] == 1
+    assert once_passed is True
+    assert once_detail["events"] == 1
+
+    records[0]["payload"]["pinned_shared_logical_ids"] = [63, 64]
+    (unit / "moe_offload_profile.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    lane_passed, lane_detail = verifier._fused_shared_lane_gate(
+        unit,
+        expected_routed_experts=64,
+        expected_shared_experts=2,
+    )
+    assert lane_passed is False
+    assert lane_detail["failures"][0]["actual"]["pinned_shared_logical_ids"] == [63, 64]
+
+
 def test_qualification_runner_uses_capacity_bounded_default_slots(
     monkeypatch,
 ):
@@ -182,6 +239,40 @@ def test_qualification_runner_uses_capacity_bounded_default_slots(
     )
 
     assert runner._parse_args().num_slots == 32
+
+
+def test_qualification_runner_propagates_ascend_additional_config(monkeypatch):
+    runner = _load(RUNNER_PATH, "issue25_runner_config_test")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_issue27_qualification.py",
+            "--model-id",
+            "deepseek-v2-lite",
+            "--model-path",
+            "/tmp/model",
+            "--output-root",
+            "/tmp/output",
+            "--device",
+            "5",
+            "--ascend-additional-config-json",
+            '{"mix_placement": true}',
+        ],
+    )
+
+    args = runner._parse_args()
+    command = runner._base_command(
+        args,
+        Path("/tmp/unit"),
+        mode="fixed_slot_sync",
+        prompt="Hi",
+        output_tokens=1,
+        slots=4,
+    )
+
+    index = command.index("--ascend-additional-config-json")
+    assert json.loads(command[index + 1]) == {"mix_placement": True}
 
 
 def test_capacity_limited_native_oracle_is_explicitly_classified(tmp_path: Path):

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -2951,3 +2951,45 @@ def test_graph_tools_default_to_graph_mode_and_reject_forced_eager(monkeypatch):
     )
     assert llm_kwargs["enable_prefix_caching"] is False
     assert llm_kwargs["compilation_config"]["cudagraph_mode"] == "PIECEWISE"
+    assert llm_kwargs["additional_config"] == {
+        "ascend_compilation_config": {"fuse_norm_quant": False}
+    }
+
+
+def test_smoke_runner_records_validated_ascend_additional_config(monkeypatch):
+    from benchmark.scripts import run_fixed_slot_smoke as benchmark_smoke
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_fixed_slot_smoke.py",
+            "--output-dir",
+            "/tmp/smoke",
+            "--ascend-additional-config-json",
+            '{"mix_placement": true}',
+        ],
+    )
+
+    args = benchmark_smoke.parse_args()
+    assert args.ascend_additional_config == {"mix_placement": True}
+    llm_kwargs = benchmark_smoke._build_llm_kwargs(
+        SimpleNamespace(
+            model="/models/deepseek",
+            enforce_eager=False,
+            gpu_memory_utilization=0.4,
+            kv_cache_memory_mb=256,
+            max_model_len=64,
+            max_num_seqs=1,
+            max_num_batched_tokens=2,
+            with_native_offload_backend=False,
+            disable_ascend_norm_quant_fusion=False,
+            ascend_additional_config=args.ascend_additional_config,
+        ),
+        {
+            "model": {"path": "/unused", "tensor_parallel_size": 1},
+            "dataset": {"seed": 42},
+        },
+        "fixed_slot_sync",
+    )
+    assert llm_kwargs["additional_config"] == {"mix_placement": True}

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -108,6 +108,355 @@ def test_runtime_patch_install_registers_custom_ops_before_moe_modules(monkeypat
     ]
 
 
+def test_mix_placement_aiter_compat_suppresses_only_parent_constructor(monkeypatch):
+    """Ascend's model-layout shim must not allocate ROCm CUDA AIter buffers."""
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    original_shared_enabled = rocm_aiter_ops.is_fusion_moe_shared_experts_enabled
+    original_fused_enabled = rocm_aiter_ops.is_fused_moe_enabled
+    monkeypatch.setattr(rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: True)
+    monkeypatch.setattr(rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
+    monkeypatch.setattr(patch_fused_moe, "_ascend_mix_placement_enabled", lambda: True)
+
+    class FakeAscendFusedMoE:
+        def __init__(self, **kwargs):
+            self.shared_probe_in_parent = (
+                rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            )
+            self.fused_probe_in_parent = rocm_aiter_ops.is_fused_moe_enabled()
+            self.n_shared_experts = kwargs["n_shared_experts"]
+
+    fake_module = SimpleNamespace(AscendFusedMoE=FakeAscendFusedMoE)
+    patch_fused_moe._patch_ascend_mix_placement_aiter_compat(fake_module)
+    layer = FakeAscendFusedMoE(n_shared_experts=2)
+
+    assert layer.shared_probe_in_parent is False
+    assert layer.fused_probe_in_parent is False
+    assert layer._latchmoe_mix_placement_aiter_suppressed is True
+    assert rocm_aiter_ops.is_fusion_moe_shared_experts_enabled() is True
+    assert rocm_aiter_ops.is_fused_moe_enabled() is True
+    assert fake_module.AscendFusedMoE._latchmoe_mix_placement_aiter_patch is True
+
+    # Keep the originals reachable for clarity if this test is run without
+    # pytest's monkeypatch teardown during an interactive investigation.
+    assert callable(original_shared_enabled)
+    assert callable(original_fused_enabled)
+
+
+def test_mix_placement_aiter_compat_leaves_external_shared_path_unchanged(monkeypatch):
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: True)
+    monkeypatch.setattr(rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
+    monkeypatch.setattr(patch_fused_moe, "_ascend_mix_placement_enabled", lambda: False)
+
+    class FakeAscendFusedMoE:
+        def __init__(self, **kwargs):
+            self.shared_probe_in_parent = (
+                rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            )
+            self.fused_probe_in_parent = rocm_aiter_ops.is_fused_moe_enabled()
+            self.n_shared_experts = kwargs["n_shared_experts"]
+
+    fake_module = SimpleNamespace(AscendFusedMoE=FakeAscendFusedMoE)
+    patch_fused_moe._patch_ascend_mix_placement_aiter_compat(fake_module)
+    layer = FakeAscendFusedMoE(n_shared_experts=2)
+
+    assert layer.shared_probe_in_parent is True
+    assert layer.fused_probe_in_parent is True
+    assert not hasattr(layer, "_latchmoe_mix_placement_aiter_suppressed")
+
+
+def test_mix_placement_aiter_compat_expands_dispatcher_top_k(monkeypatch):
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: True)
+    monkeypatch.setattr(rocm_aiter_ops, "is_fused_moe_enabled", lambda: True)
+    monkeypatch.setattr(patch_fused_moe, "_ascend_mix_placement_enabled", lambda: True)
+    setup_calls = []
+
+    class FakeAscendFusedMoE:
+        def __init__(self, **kwargs):
+            self.n_shared_experts = kwargs["n_shared_experts"]
+            self.moe_config = SimpleNamespace(experts_per_token=6)
+
+    fake_module = SimpleNamespace(
+        AscendFusedMoE=FakeAscendFusedMoE,
+        setup_moe_comm_method=lambda config: setup_calls.append(config.experts_per_token),
+    )
+    patch_fused_moe._patch_ascend_mix_placement_aiter_compat(fake_module)
+    layer = FakeAscendFusedMoE(n_shared_experts=2)
+
+    assert layer.moe_config.experts_per_token == 8
+    assert layer._latchmoe_mix_placement_dispatch_top_k == 8
+    assert setup_calls == [8]
+
+
+def test_mix_placement_router_compat_appends_shared_suffix_arguments(monkeypatch):
+    """Pinned Ascend must tell its selector about materialized shared rows."""
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+
+    calls = []
+
+    class FakeBaseMethod:
+        def create_weights(self, *args, **kwargs):
+            del args, kwargs
+
+    class FakeAscendMethod(FakeBaseMethod):
+        def process_weights_after_loading(self, layer):
+            del layer
+
+        def apply(self, *, layer, **kwargs):
+            return fake_module.select_experts(
+                hidden_states=kwargs["hidden_states"],
+                router_logits=kwargs["router_logits"],
+                num_experts=kwargs["num_experts"],
+            )
+
+    def original_select_experts(**kwargs):
+        calls.append(kwargs)
+        return "weights", "ids"
+
+    fake_module = SimpleNamespace(
+        AscendUnquantizedFusedMoEMethod=FakeAscendMethod,
+        UnquantizedFusedMoEMethod=FakeBaseMethod,
+        select_experts=original_select_experts,
+    )
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(offload_stage_seam=False),
+        should_use_fixed_slot_plan_for_layer=lambda _layer_id: False,
+    )
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+
+    patch_fused_moe._patch_unquantized_moe_method(fake_module)
+    layer = SimpleNamespace(layer_id=7, mix_placement=True, n_shared_experts=2)
+    hidden_states = object()
+    router_logits = object()
+    assert FakeAscendMethod().apply(
+        layer=layer,
+        hidden_states=hidden_states,
+        router_logits=router_logits,
+        num_experts=64,
+    ) == ("weights", "ids")
+
+    assert calls == [
+        {
+            "hidden_states": hidden_states,
+            "router_logits": router_logits,
+            "num_experts": 64,
+            "mix_placement": True,
+            "num_logical_experts": 64,
+            "num_shared_experts": 2,
+        }
+    ]
+
+
+def test_mix_placement_router_compat_leaves_regular_selector_arguments_unchanged(monkeypatch):
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+
+    calls = []
+
+    class FakeBaseMethod:
+        def create_weights(self, *args, **kwargs):
+            del args, kwargs
+
+    class FakeAscendMethod(FakeBaseMethod):
+        def process_weights_after_loading(self, layer):
+            del layer
+
+        def apply(self, *, layer, **kwargs):
+            return fake_module.select_experts(
+                hidden_states=kwargs["hidden_states"],
+                router_logits=kwargs["router_logits"],
+                num_experts=kwargs["num_experts"],
+            )
+
+    def original_select_experts(**kwargs):
+        calls.append(kwargs)
+        return "weights", "ids"
+
+    fake_module = SimpleNamespace(
+        AscendUnquantizedFusedMoEMethod=FakeAscendMethod,
+        UnquantizedFusedMoEMethod=FakeBaseMethod,
+        select_experts=original_select_experts,
+    )
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(offload_stage_seam=False),
+        should_use_fixed_slot_plan_for_layer=lambda _layer_id: False,
+    )
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+
+    patch_fused_moe._patch_unquantized_moe_method(fake_module)
+    layer = SimpleNamespace(layer_id=7, mix_placement=False, n_shared_experts=2)
+    assert FakeAscendMethod().apply(
+        layer=layer,
+        hidden_states=object(),
+        router_logits=object(),
+        num_experts=64,
+    ) == ("weights", "ids")
+
+    assert list(calls[0]) == ["hidden_states", "router_logits", "num_experts"]
+
+
+def test_mix_placement_injected_topk_preserves_shared_suffix_during_profile(monkeypatch):
+    """Profile balancing must not rewrite a fused shared suffix as routed IDs."""
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_seam_inject
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+
+    class FakeBaseMethod:
+        def create_weights(self, *args, **kwargs):
+            del args, kwargs
+
+    class FakeAscendMethod(FakeBaseMethod):
+        def process_weights_after_loading(self, layer):
+            del layer
+
+        def apply(self, *, layer, **kwargs):
+            del layer
+            return kwargs["enable_force_load_balance"]
+
+    profile_events = []
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(offload_stage_seam=False),
+        should_use_fixed_slot_plan_for_layer=lambda _layer_id: False,
+        fused_shared_lane_layout=lambda layer_id: (
+            SimpleNamespace(
+                routed_expert_count=64,
+                shared_expert_count=2,
+            )
+            if layer_id == 7
+            else None
+        ),
+        _record_profile_event=lambda *args, **kwargs: profile_events.append(
+            (args, kwargs)
+        ),
+    )
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+    fake_module = SimpleNamespace(
+        AscendUnquantizedFusedMoEMethod=FakeAscendMethod,
+        UnquantizedFusedMoEMethod=FakeBaseMethod,
+        select_experts=lambda **_kwargs: ("weights", "ids"),
+    )
+    patch_fused_moe._patch_unquantized_moe_method(fake_module)
+
+    topk_ids = SimpleNamespace(shape=(3, 8))
+    moe_seam_inject.set_injected_topk(7, object(), topk_ids)
+    try:
+        assert FakeAscendMethod().apply(
+            layer=SimpleNamespace(layer_id=7),
+            enable_force_load_balance=True,
+        ) is False
+    finally:
+        moe_seam_inject.clear_injected_topk(7)
+
+    assert profile_events[0][0] == ("fused_shared_profile_router_preserved",)
+    assert profile_events[0][1]["layer_id"] == 7
+    assert profile_events[0][1]["payload"] == {
+        "routed_expert_count": 64,
+        "shared_expert_count": 2,
+        "topk_width": 8,
+    }
+
+
+def test_mix_placement_router_parity_compares_appended_shared_suffix(monkeypatch):
+    """The eager router oracle must use the same 6+routed shared ABI as seam."""
+    import torch
+
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_seam_inject
+    from vllm_moe_offload_ascend.moe_offload import router_parity
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+
+    class FakeBaseMethod:
+        def create_weights(self, *args, **kwargs):
+            del args, kwargs
+
+    class FakeAscendMethod(FakeBaseMethod):
+        def process_weights_after_loading(self, layer):
+            del layer
+
+        def apply(self, *, layer, **kwargs):
+            return fake_module.select_experts(
+                hidden_states=kwargs["hidden_states"],
+                router_logits=kwargs["router_logits"],
+                num_experts=kwargs["num_experts"],
+            )
+
+    calls = []
+    snapshots = []
+    injected_weights = torch.tensor([[0.4, 0.3, 1.0, 1.0]])
+    injected_ids = torch.tensor([[10, 11, 64, 65]], dtype=torch.int32)
+
+    def native_selector(**kwargs):
+        calls.append(kwargs)
+        assert kwargs["mix_placement"] is True
+        assert kwargs["num_logical_experts"] == 64
+        assert kwargs["num_shared_experts"] == 2
+        return injected_weights, injected_ids
+
+    runtime = SimpleNamespace(
+        config=SimpleNamespace(offload_stage_seam=False),
+        should_use_fixed_slot_plan_for_layer=lambda _layer_id: False,
+        fused_shared_lane_layout=lambda layer_id: (
+            SimpleNamespace(routed_expert_count=64, shared_expert_count=2)
+            if layer_id == 7
+            else None
+        ),
+    )
+    fake_module = SimpleNamespace(
+        AscendUnquantizedFusedMoEMethod=FakeAscendMethod,
+        UnquantizedFusedMoEMethod=FakeBaseMethod,
+        select_experts=native_selector,
+    )
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+    monkeypatch.setattr(
+        router_parity,
+        "record_router_snapshot",
+        lambda **kwargs: snapshots.append(kwargs),
+    )
+    monkeypatch.setenv("VLLM_ASCEND_MOE_OFFLOAD_COMPARE_ROUTER", "1")
+    patch_fused_moe._patch_unquantized_moe_method(fake_module)
+
+    moe_seam_inject.set_injected_topk(7, injected_weights, injected_ids)
+    try:
+        actual = FakeAscendMethod().apply(
+            layer=SimpleNamespace(layer_id=7),
+            hidden_states=torch.zeros((1, 4)),
+            router_logits=torch.zeros((1, 64)),
+            num_experts=64,
+        )
+    finally:
+        moe_seam_inject.clear_injected_topk(7)
+
+    assert actual == (injected_weights, injected_ids)
+    assert len(calls) == 1
+    assert snapshots == [
+        {
+            "role": "native",
+            "layer_id": 7,
+            "router_logits": calls[0]["router_logits"],
+            "topk_ids": injected_ids,
+            "topk_weights": injected_weights,
+        }
+    ]
+
+
+def test_summarize_fused_shared_ids_is_bounded_and_unique():
+    import torch
+
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    assert patch_fused_moe._summarize_fused_shared_ids(
+        torch.tensor([[65, 64], [64, 65]], dtype=torch.int32)
+    ) == [64, 65]
+
+
 def test_cann_compat_install_does_not_install_moe_runtime(monkeypatch):
     import importlib
 

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -2809,7 +2809,8 @@ def test_seam_guard_requires_matching_fused_shared_lane(
     layer = SimpleNamespace(
         layer_id=11,
         moe_config=SimpleNamespace(
-            num_experts=4, dp_size=1, ep_size=1, tp_size=1, pcp_size=1
+            # Ascend FusedMoE mutates this count to include the two shared rows.
+            num_experts=6, dp_size=1, ep_size=1, tp_size=1, pcp_size=1
         ),
         n_shared_experts=2,
         mix_placement=True,

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -1594,7 +1594,7 @@ def test_b2_fused_shared_executes_pinned_suffix_once_and_combines_outputs(monkey
         _ascend_moe_offload_runtime_patch = False
 
         def fused_experts(self, fused_experts_input):
-            shared_calls.append(fused_experts_input)
+            shared_calls.append((fused_experts_input, self.token_dispatcher.top_k))
             return FakeFusedExpertsResult(
                 routed_out=torch.full_like(fused_experts_input.hidden_states, 3.0),
                 dispatch_marker="shared",
@@ -1637,6 +1637,7 @@ def test_b2_fused_shared_executes_pinned_suffix_once_and_combines_outputs(monkey
     patch_fused_moe._patch_moe_comm_method_runtime_hooks(fake_comm)
 
     comm = FakeCommMethod()
+    comm.token_dispatcher = SimpleNamespace(top_k=2)
     routed_calls = []
 
     def run_routed_b2(**kwargs):
@@ -1681,8 +1682,11 @@ def test_b2_fused_shared_executes_pinned_suffix_once_and_combines_outputs(monkey
     assert routed_calls[0]["fused_experts_input"].topk_ids.tolist() == [[0, 1], [1, 0]]
     assert routed_calls[0]["control_profile"]["pair_offsets_by_expert"] is None
     assert len(shared_calls) == 1
-    assert shared_calls[0].topk_ids.tolist() == [[2], [2]]
-    assert shared_calls[0].topk_weights.tolist() == [[1.0], [1.0]]
+    shared_input, dispatch_top_k = shared_calls[0]
+    assert dispatch_top_k == 1
+    assert shared_input.topk_ids.tolist() == [[2], [2]]
+    assert shared_input.topk_weights.tolist() == [[1.0], [1.0]]
+    assert comm.token_dispatcher.top_k == 2
     assert pinned_weights.expected_device_types == ["cpu"]
     assert torch.equal(result.routed_out, torch.full((2, 4), 5.0))
     assert result.dispatch_marker == "routed"

--- a/tests/test_patch_fused_moe.py
+++ b/tests/test_patch_fused_moe.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -1488,6 +1489,218 @@ def test_b2_runs_exact_pair_waves_for_multi_request_decode_overflow(monkeypatch)
     assert calls[0]["control_profile"]["forward_phase"] == "decode"
 
 
+def test_b2_fused_shared_counts_only_routed_pairs_for_wave_capacity(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    class FakeCommMethod:
+        _ascend_moe_offload_runtime_patch = False
+
+        def fused_experts(self, fused_experts_input):
+            return "native"
+
+        def _maybe_apply_moe_offload_plan(self, fused_experts_input):
+            return fused_experts_input
+
+    fused_layout = SimpleNamespace(
+        routed_expert_count=2,
+        shared_expert_count=1,
+        total_logical_expert_count=3,
+    )
+
+    class FakeRuntime:
+        config = SimpleNamespace(
+            graph_compatible_offload=False,
+            b2_wave_prefill=True,
+            gmm_profile_path="",
+            max_num_seqs_hint=0,
+            num_slots=1,
+        )
+
+        def fused_shared_lane_layout(self, layer_id):
+            assert int(layer_id) == 7
+            return fused_layout
+
+        def is_resident_layer(self, layer_id):
+            return False
+
+        def should_use_fixed_slot_plan_for_layer(self, layer_id):
+            return True
+
+        def consume_prefill_route_stats_record(self, **kwargs):
+            return None
+
+        def should_use_b2_pair_waves(self, *, layer_id, active_expert_count):
+            return active_expert_count > self.config.num_slots
+
+    monkeypatch.setattr(patch_fused_moe, "_current_forward_is_prefill", lambda: False)
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: FakeRuntime())
+    fake_comm = SimpleNamespace(
+        MoECommMethod=FakeCommMethod,
+        build_token_dispatch_input=lambda **kwargs: kwargs,
+        build_mlp_compute_input=lambda **kwargs: kwargs,
+        FusedExpertsResult=SimpleNamespace,
+        MoEFusedExpertsInput=SimpleNamespace,
+        MoEWeights=SimpleNamespace,
+        MoEOffloadParams=SimpleNamespace,
+        MoERoutingParams=SimpleNamespace,
+        setup_moe_comm_method=None,
+    )
+    patch_fused_moe._patch_moe_comm_method_runtime_hooks(fake_comm)
+
+    comm = FakeCommMethod()
+    TokenDispatcherWithAllGather = type("TokenDispatcherWithAllGather", (), {})
+    comm.token_dispatcher = TokenDispatcherWithAllGather()
+    calls = []
+    comm._run_b2_fused_shared_once = lambda **kwargs: calls.append(kwargs) or "b2"
+    fused_experts_input = SimpleNamespace(
+        hidden_states=torch.empty((2, 16)),
+        topk_ids=torch.tensor([[0, 1, 2], [1, 0, 2]]),
+        topk_weights=torch.ones((2, 3)),
+        offload=SimpleNamespace(enabled=True, layer_id=7),
+    )
+
+    assert comm._maybe_run_b2_wave_prefill(
+        fused_experts_input,
+        before_dispatch_evt=None,
+    ) == "b2"
+    assert calls[0]["token_counts"] == {0: 2, 1: 2}
+    assert calls[0]["control_profile"]["pair_offsets_by_expert"] is None
+
+
+def test_b2_fused_shared_executes_pinned_suffix_once_and_combines_outputs(monkeypatch):
+    import torch
+
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_impl
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+
+    @dataclass(frozen=True)
+    class FakeFusedExpertsInput:
+        hidden_states: object
+        topk_ids: object
+        topk_weights: object
+        offload: object
+
+    @dataclass(frozen=True)
+    class FakeFusedExpertsResult:
+        routed_out: object
+        dispatch_marker: str
+
+    shared_calls = []
+
+    class FakeCommMethod:
+        _ascend_moe_offload_runtime_patch = False
+
+        def fused_experts(self, fused_experts_input):
+            shared_calls.append(fused_experts_input)
+            return FakeFusedExpertsResult(
+                routed_out=torch.full_like(fused_experts_input.hidden_states, 3.0),
+                dispatch_marker="shared",
+            )
+
+        def _maybe_apply_moe_offload_plan(self, fused_experts_input):
+            return fused_experts_input
+
+    class PinnedWeights:
+        def __init__(self):
+            self.expected_device_types = []
+
+        def validate_backend_ready(self, *, expected_device_type):
+            self.expected_device_types.append(expected_device_type)
+
+    pinned_weights = PinnedWeights()
+    events = []
+
+    class FakeRuntime:
+        def capture_safe_slot_weights(self, *, layer_id):
+            assert int(layer_id) == 7
+            return pinned_weights
+
+        def _record_profile_event(self, name, *, layer_id, start, payload):
+            events.append((name, int(layer_id), payload))
+
+    runtime = FakeRuntime()
+    monkeypatch.setattr(runtime_impl, "get_moe_offload_runtime", lambda: runtime)
+    fake_comm = SimpleNamespace(
+        MoECommMethod=FakeCommMethod,
+        build_token_dispatch_input=lambda **kwargs: kwargs,
+        build_mlp_compute_input=lambda **kwargs: kwargs,
+        FusedExpertsResult=FakeFusedExpertsResult,
+        MoEFusedExpertsInput=FakeFusedExpertsInput,
+        MoEWeights=SimpleNamespace,
+        MoEOffloadParams=SimpleNamespace,
+        MoERoutingParams=SimpleNamespace,
+        setup_moe_comm_method=None,
+    )
+    patch_fused_moe._patch_moe_comm_method_runtime_hooks(fake_comm)
+
+    comm = FakeCommMethod()
+    routed_calls = []
+
+    def run_routed_b2(**kwargs):
+        routed_calls.append(kwargs)
+        return FakeFusedExpertsResult(
+            routed_out=torch.full_like(
+                kwargs["fused_experts_input"].hidden_states,
+                2.0,
+            ),
+            dispatch_marker="routed",
+        )
+
+    comm._run_b2_wave_prefill = run_routed_b2
+    comm._with_prepared_slot_weights = lambda input_value, weights: (
+        input_value if weights is pinned_weights else None
+    )
+    fused_experts_input = FakeFusedExpertsInput(
+        hidden_states=torch.zeros((2, 4)),
+        topk_ids=torch.tensor([[0, 1, 2], [1, 0, 2]], dtype=torch.int32),
+        topk_weights=torch.tensor([[0.6, 0.4, 1.0], [0.7, 0.3, 1.0]]),
+        offload=SimpleNamespace(
+            enabled=True,
+            layer_id=7,
+            expected_device_type="cpu",
+        ),
+    )
+    layout = SimpleNamespace(
+        routed_expert_count=2,
+        shared_expert_count=1,
+        total_logical_expert_count=3,
+    )
+
+    result = comm._run_b2_fused_shared_once(
+        fused_experts_input=fused_experts_input,
+        before_dispatch_evt=None,
+        token_counts={0: 2, 1: 2},
+        shared_layout=layout,
+        control_profile={"pair_offsets_by_expert": (0, 1)},
+    )
+
+    assert len(routed_calls) == 1
+    assert routed_calls[0]["fused_experts_input"].topk_ids.tolist() == [[0, 1], [1, 0]]
+    assert routed_calls[0]["control_profile"]["pair_offsets_by_expert"] is None
+    assert len(shared_calls) == 1
+    assert shared_calls[0].topk_ids.tolist() == [[2], [2]]
+    assert shared_calls[0].topk_weights.tolist() == [[1.0], [1.0]]
+    assert pinned_weights.expected_device_types == ["cpu"]
+    assert torch.equal(result.routed_out, torch.full((2, 4), 5.0))
+    assert result.dispatch_marker == "routed"
+    assert events == [
+        (
+            "fused_shared_b2_once",
+            7,
+            {
+                "routed_expert_count": 2,
+                "pinned_shared_expert_count": 1,
+                "shared_pairs": 2,
+                "shared_pair_execution_count": 1,
+                "routed_pairs": 4,
+            },
+        )
+    ]
+
+
 def test_profile_b2_runs_without_explicit_feature_flag(monkeypatch):
     import torch
 
@@ -2262,6 +2475,31 @@ def test_moe_router_fake_returns_hidden_states_dtype_not_logits_dtype():
     assert topk_ids.shape == (4, 2)
 
 
+def test_moe_router_fake_appends_fused_shared_suffix_shape():
+    import torch
+
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_router_op
+
+    topk_weights, topk_ids = moe_router_op._moe_router_fake(
+        hidden_states=torch.empty((3, 16), dtype=torch.bfloat16),
+        router_logits=torch.empty((3, 64), dtype=torch.float32),
+        top_k=2,
+        use_grouped_topk=False,
+        renormalize=True,
+        topk_group=None,
+        num_expert_group=None,
+        scoring_func="softmax",
+        routed_scaling_factor=1.0,
+        e_score_correction_bias=None,
+        num_experts=64,
+        mix_placement=True,
+        num_shared_experts=2,
+    )
+
+    assert topk_weights.shape == (3, 4)
+    assert topk_ids.shape == (3, 4)
+
+
 def test_moe_router_indirect_uses_ascend_original_routed_scaling_factor(monkeypatch):
     """The seam must match AscendFusedMoE.apply after vLLM rewrites the layer field."""
     import torch
@@ -2314,6 +2552,62 @@ def test_moe_router_indirect_uses_ascend_original_routed_scaling_factor(monkeypa
     )
 
     assert calls[0]["routed_scaling_factor"] == 1.8
+
+
+def test_moe_router_indirect_forwards_fused_shared_suffix_arguments(monkeypatch):
+    import torch
+
+    from vllm_moe_offload_ascend.ops.fused_moe import moe_router_op
+
+    layer = SimpleNamespace(
+        layer_id=7,
+        runner=None,
+        top_k=2,
+        use_grouped_topk=False,
+        renormalize=True,
+        topk_group=None,
+        num_expert_group=None,
+        scoring_func="softmax",
+        routed_scaling_factor=1.0,
+        e_score_correction_bias=None,
+        custom_routing_function=None,
+        n_shared_experts=2,
+        mix_placement=True,
+        global_redundant_expert_num=0,
+        moe_config=SimpleNamespace(num_experts=66),
+    )
+    calls = []
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.fused_moe.runner.moe_runner.get_layer_from_name",
+        lambda _name: layer,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.quantization.methods.base.get_moe_num_logical_experts",
+        lambda *_args, **_kwargs: 64,
+    )
+
+    def fake_select_experts(**kwargs):
+        calls.append(kwargs)
+        return torch.ones((4, 4), dtype=torch.bfloat16), torch.zeros(
+            (4, 4), dtype=torch.int32
+        )
+
+    monkeypatch.setattr(
+        "vllm_ascend.ops.fused_moe.experts_selector.select_experts",
+        fake_select_experts,
+    )
+
+    weights, ids = moe_router_op._moe_router_indirect_impl(
+        torch.zeros((4, 16), dtype=torch.bfloat16),
+        torch.zeros((4, 64), dtype=torch.float32),
+        "fixture.layer.experts",
+    )
+
+    assert weights.shape == ids.shape == (4, 4)
+    assert calls[0]["num_experts"] == 64
+    assert calls[0]["num_logical_experts"] == 64
+    assert calls[0]["mix_placement"] is True
+    assert calls[0]["num_shared_experts"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -2461,6 +2755,94 @@ def test_seam_guard_resolves_external_gated_internal_corrected_router(monkeypatc
             "shared_gate": runner.shared_expert_gate,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("layout", "enabled", "blocker"),
+    [
+        (None, False, "fused_shared_lane_unregistered"),
+        (
+            SimpleNamespace(
+                routed_expert_count=3,
+                shared_expert_count=2,
+                pinned_logical_ids=(3, 4),
+                total_logical_expert_count=5,
+            ),
+            False,
+            "fused_shared_lane_layout_mismatch",
+        ),
+        (
+            SimpleNamespace(
+                routed_expert_count=4,
+                shared_expert_count=2,
+                pinned_logical_ids=(4, 5),
+                total_logical_expert_count=6,
+            ),
+            True,
+            None,
+        ),
+    ],
+)
+def test_seam_guard_requires_matching_fused_shared_lane(
+    monkeypatch,
+    layout,
+    enabled,
+    blocker,
+):
+    from vllm_moe_offload_ascend.patches import patch_fused_moe
+    import vllm_moe_offload_ascend.moe_offload.runtime as runtime_mod
+
+    class FakeRunner:
+        _ascend_moe_offload_seam_patch = False
+
+        def _select_forward(self):
+            raise AssertionError("should not be called")
+
+    class FakeRuntime:
+        def fused_shared_lane_layout(self, layer_id):
+            assert int(layer_id) == 11
+            return layout
+
+    patch_fused_moe._patch_ascend_moe_runner(
+        SimpleNamespace(AscendMoERunner=FakeRunner)
+    )
+    layer = SimpleNamespace(
+        layer_id=11,
+        moe_config=SimpleNamespace(
+            num_experts=4, dp_size=1, ep_size=1, tp_size=1, pcp_size=1
+        ),
+        n_shared_experts=2,
+        mix_placement=True,
+        top_k=2,
+        use_grouped_topk=False,
+        topk_group=None,
+        num_expert_group=None,
+        renormalize=True,
+        scoring_func="softmax",
+        e_score_correction_bias=None,
+        routed_scaling_factor=1.0,
+        custom_routing_function=None,
+        enable_npugraph_ex_static_kernel=False,
+        zero_expert_num=0,
+        zero_expert_type=None,
+    )
+    from vllm.model_executor.layers.fused_moe.runner import moe_runner as mr
+
+    monkeypatch.setattr(runtime_mod, "get_moe_offload_runtime", lambda: FakeRuntime())
+    monkeypatch.setattr(mr, "get_layer_from_name", lambda _name: layer)
+    runner = FakeRunner()
+    runner.layer_name = "fixture.layer.experts"
+    runner._shared_experts = None
+    runner.shared_expert_gate = None
+    runner.gate = None
+
+    assert runner._resolve_seam_per_layer_guards() is enabled
+    support = runner._seam_capability_support
+    if blocker is None:
+        assert support.enabled
+    else:
+        assert not support.enabled
+        assert blocker in support.blockers
 
 
 def test_compile_tracing_probe_is_module_scoped_for_dynamo_capture():

--- a/tests/test_prefill_stage_runtime.py
+++ b/tests/test_prefill_stage_runtime.py
@@ -21,6 +21,22 @@ class TinyLayer(torch.nn.Module):
         )
 
 
+class TinyFusedSharedLayer(torch.nn.Module):
+    """Four routed rows followed by two mix-placement shared rows."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer_id = 9
+        self.mix_placement = True
+        self.n_shared_experts = 2
+        self.w13_weight = torch.nn.Parameter(
+            torch.arange(6 * 2 * 3, dtype=torch.float32).reshape(6, 2, 3)
+        )
+        self.w2_weight = torch.nn.Parameter(
+            torch.arange(6 * 3 * 2, dtype=torch.float32).reshape(6, 3, 2)
+        )
+
+
 def test_slot_bank_lookup_expert_id_tracks_resident_index():
     bank = ExpertSlotBank(
         2,
@@ -206,6 +222,121 @@ def test_memory_ledger_separates_resident_shared_weights_from_shared_gate():
         shared_gate=shared.expert_gate,
     )
     assert runtime.memory_ledger().total_managed_bytes == ledger.total_managed_bytes
+
+
+def test_fused_shared_lane_pins_suffix_and_offloads_only_routed_rows():
+    runtime = MoeOffloadRuntime(
+        MoeOffloadConfig(
+            enabled=True,
+            num_slots=2,
+            release_original_expert_weights=True,
+        )
+    )
+    layer = TinyFusedSharedLayer()
+    original_w13 = layer.w13_weight.detach().clone()
+    original_w2 = layer.w2_weight.detach().clone()
+
+    runtime.register_layer_for_fixed_slots(layer, slot_device=torch.device("cpu"))
+
+    layout = runtime.fused_shared_lane_layout(layer.layer_id)
+    assert layout is not None
+    assert layout.routed_expert_count == 4
+    assert layout.shared_expert_count == 2
+    assert layout.pinned_logical_ids == (4, 5)
+
+    bank = runtime._slot_banks[layer.layer_id]
+    assert len(bank.slots) == 2
+    assert bank.physical_expert_count == 4
+    assert bank.pinned_slot_ids == (2, 3)
+    assert torch.equal(bank.w13_slots[2:], original_w13[4:])
+    assert torch.equal(bank.w2_slots[2:], original_w2[4:])
+    assert len(runtime._host_store) == 4
+    with pytest.raises(KeyError):
+        runtime._host_store.get(layer.layer_id, 4)
+
+    prepared = runtime.prepare_fixed_slot_plan(
+        layer_id=layer.layer_id,
+        active_experts=(3, 0),
+        num_logical_experts=4,
+        device=torch.device("cpu"),
+    )
+    assert prepared.physical_expert_count == 4
+    assert prepared.log2phy.tolist() == [1, -1, -1, 0, 2, 3]
+    assert prepared.mapping.slot_to_expert == (3, 0, 4, 5)
+    assert torch.equal(prepared.w1[2:], original_w13[4:])
+
+    with pytest.raises(ValueError, match="out of range"):
+        runtime.prepare_fixed_slot_plan(
+            layer_id=layer.layer_id,
+            active_experts=(4,),
+            num_logical_experts=4,
+            device=torch.device("cpu"),
+        )
+
+    ledger = runtime.memory_ledger()
+    dynamic_row_bytes = (
+        original_w13[0].numel() * original_w13.element_size()
+        + original_w2[0].numel() * original_w2.element_size()
+    )
+    assert ledger.slot_bank_bytes == 2 * dynamic_row_bytes
+    assert ledger.pinned_shared_lane_bytes == 2 * dynamic_row_bytes
+    assert ledger.host_experts == 4
+
+    persisted = runtime.stage_fixed_slot_plan(
+        layer_id=layer.layer_id,
+        active_experts=(3, 0),
+        num_logical_experts=4,
+    )
+    assert persisted.log2phy.tolist() == [1, -1, -1, 0, 2, 3]
+
+    release_plan = runtime.release_original_expert_weights_if_ready(layer)
+    assert release_plan.ready
+    assert layer.w13_weight.numel() == 0
+    captured = runtime.capture_safe_slot_weights(layer_id=layer.layer_id)
+    assert captured is not None
+    assert captured.log2phy.tolist() == [1, -1, -1, 0, 2, 3]
+    assert torch.equal(captured.w2[2:], original_w2[4:])
+
+
+def test_fused_shared_lane_prefill_and_full_layer_keep_pinned_suffix_once():
+    runtime = MoeOffloadRuntime(MoeOffloadConfig(enabled=True, num_slots=2))
+    layer = TinyFusedSharedLayer()
+    original_w13 = layer.w13_weight.detach().clone()
+    original_w2 = layer.w2_weight.detach().clone()
+    runtime.register_layer_for_fixed_slots(layer, slot_device=torch.device("cpu"))
+
+    staged, _, payload = runtime.prepare_prefill_stage_plan(
+        layer_id=layer.layer_id,
+        active_experts=(1, 3),
+        num_logical_experts=4,
+        device=torch.device("cpu"),
+        buffer_index=0,
+        async_load=False,
+    )
+    assert staged.physical_expert_count == 4
+    assert staged.log2phy.tolist() == [-1, 0, -1, 1, 2, 3]
+    assert staged.mapping.slot_to_expert == (1, 3, 4, 5)
+    assert torch.equal(staged.w1[2:], original_w13[4:])
+    assert torch.equal(staged.w2[2:], original_w2[4:])
+    assert payload["miss_experts"] == [1, 3]
+    assert payload["h2d_bytes"] == 2 * (
+        original_w13[0].numel() * original_w13.element_size()
+        + original_w2[0].numel() * original_w2.element_size()
+    )
+
+    full, full_payload = runtime.prepare_full_layer_prefill_plan(
+        layer_id=layer.layer_id,
+        num_logical_experts=4,
+        device=torch.device("cpu"),
+    )
+    assert full.physical_expert_count == 6
+    assert full.log2phy.tolist() == [0, 1, 2, 3, 4, 5]
+    assert full.mapping.active_experts == (0, 1, 2, 3)
+    assert full.mapping.slot_to_expert == (0, 1, 2, 3, 4, 5)
+    assert torch.equal(full.w1, original_w13)
+    assert torch.equal(full.w2, original_w2)
+    assert full_payload["routed_expert_count"] == 4
+    assert full_payload["pinned_shared_expert_count"] == 2
 
 
 def test_memory_ledger_unwraps_vllm_shared_experts_adapter():

--- a/vllm_moe_offload_ascend/moe_offload/capabilities.py
+++ b/vllm_moe_offload_ascend/moe_offload/capabilities.py
@@ -228,7 +228,11 @@ def evaluate_support(descriptor: MoeCapabilityDescriptor) -> CapabilitySupport:
     blockers: list[str] = []
     if descriptor.output_contract not in {"routed_tensor", "shared_routed_tuple"}:
         blockers.append(f"unknown_output_contract:{descriptor.output_contract}")
-    if descriptor.shared_mode not in {"none", "external_resident"}:
+    if descriptor.shared_mode not in {
+        "none",
+        "external_resident",
+        "fused_mix_placement",
+    }:
         blockers.append(f"unsupported_shared_mode:{descriptor.shared_mode}")
     if descriptor.router_owner not in {"external_logits", "internal_gate"}:
         blockers.append(f"unsupported_router_owner:{descriptor.router_owner}")

--- a/vllm_moe_offload_ascend/moe_offload/capabilities.py
+++ b/vllm_moe_offload_ascend/moe_offload/capabilities.py
@@ -98,13 +98,29 @@ def describe_layer_capability(layer: Any, runner: Any) -> MoeCapabilityDescripto
     """Describe a materialized FusedMoE layer without model-name checks."""
 
     moe_config = getattr(layer, "moe_config", None) or getattr(runner, "moe_config", None)
-    routed_expert_count = _positive_int(
+    materialized_expert_count = _positive_int(
         getattr(moe_config, "num_experts", None),
         _positive_int(getattr(layer, "num_experts", None), 0),
     )
     external_shared = getattr(runner, "_shared_experts", None)
     mix_placement = bool(getattr(layer, "mix_placement", False))
     shared_expert_count = _positive_int(getattr(layer, "n_shared_experts", None), 0)
+    # Ascend FusedMoE mutates ``moe_config.num_experts`` after construction to
+    # include the appended shared suffix. Prefer the backend's preserved
+    # logical routed count when it exists; otherwise derive the routed range
+    # from the materialized total. This deliberately mirrors
+    # ``get_moe_num_logical_experts`` in vLLM-Ascend.
+    routed_expert_count = materialized_expert_count
+    if mix_placement:
+        preserved_routed_count = _positive_int(
+            getattr(moe_config, "num_logical_experts", None),
+            0,
+        )
+        routed_expert_count = (
+            preserved_routed_count
+            if preserved_routed_count > 0
+            else materialized_expert_count - shared_expert_count
+        )
     if external_shared is not None:
         shared_mode: SharedMode = "external_resident"
         output_contract: OutputContract = "shared_routed_tuple"

--- a/vllm_moe_offload_ascend/moe_offload/host_store.py
+++ b/vllm_moe_offload_ascend/moe_offload/host_store.py
@@ -115,6 +115,7 @@ class HostExpertStore:
         *,
         pin_memory: bool = False,
         clone_tensors: bool = True,
+        routed_expert_count: int | None = None,
     ) -> HostStoreRegisterReport:
         layer_id = int(getattr(layer, "layer_id", -1))
         w13_weight = getattr(layer, "w13_weight")
@@ -122,19 +123,29 @@ class HostExpertStore:
         if w13_weight.shape[0] != w2_weight.shape[0]:
             raise ValueError("w13_weight and w2_weight must have the same number of experts")
 
-        num_experts = int(w13_weight.shape[0])
+        total_experts = int(w13_weight.shape[0])
+        num_experts = (
+            total_experts
+            if routed_expert_count is None
+            else int(routed_expert_count)
+        )
         if num_experts <= 0:
             raise ValueError("host expert store requires at least one expert")
+        if num_experts > total_experts:
+            raise ValueError(
+                "routed expert count exceeds materialized expert rows: "
+                f"routed={num_experts}, total={total_experts}"
+            )
         self._weights = {key: bundle for key, bundle in self._weights.items() if key.layer_id != layer_id}
         self._weights_by_layer.pop(layer_id, None)
         self._layer_buffers.pop(layer_id, None)
         w13_host, w13_pinned, w13_error = _to_host_layer_tensor(
-            w13_weight,
+            w13_weight[:num_experts],
             clone=clone_tensors,
             pin_memory=pin_memory,
         )
         w2_host, w2_pinned, w2_error = _to_host_layer_tensor(
-            w2_weight,
+            w2_weight[:num_experts],
             clone=clone_tensors,
             pin_memory=pin_memory,
         )
@@ -179,7 +190,13 @@ class HostExpertStore:
         normalized_expert_id = int(expert_id)
         layer_bundles = self._weights_by_layer.get(normalized_layer_id)
         if layer_bundles is not None:
-            return layer_bundles[normalized_expert_id]
+            try:
+                return layer_bundles[normalized_expert_id]
+            except IndexError as exc:
+                raise KeyError(
+                    f"expert {normalized_expert_id} is not host-managed for "
+                    f"layer {normalized_layer_id}"
+                ) from exc
         return self._weights[ExpertKey(normalized_layer_id, normalized_expert_id)]
 
     def get_layer_buffer(self, layer_id: int) -> HostExpertLayerBuffer:

--- a/vllm_moe_offload_ascend/moe_offload/runtime.py
+++ b/vllm_moe_offload_ascend/moe_offload/runtime.py
@@ -74,6 +74,10 @@ class MoeOffloadMemoryLedger:
     full_layer_prefill_bank_count: int = 0
     full_layer_prefill_bank_bytes: int = 0
     full_layer_prefill_mapping_bytes: int = 0
+    # Fused/mix-placement shared rows live in a stable suffix of the physical
+    # slot tensors. They are resident HBM, but are deliberately not part of the
+    # dynamic routed-slot capacity or cache accounting.
+    pinned_shared_lane_bytes: int = 0
     resident_shared_weight_bytes: int = 0
     shared_gate_weight_bytes: int = 0
 
@@ -91,6 +95,7 @@ class MoeOffloadMemoryLedger:
             + self.prefill_stage_mapping_bytes
             + self.full_layer_prefill_bank_bytes
             + self.full_layer_prefill_mapping_bytes
+            + self.pinned_shared_lane_bytes
             + self.resident_shared_weight_bytes
             + self.shared_gate_weight_bytes
         )
@@ -99,6 +104,7 @@ class MoeOffloadMemoryLedger:
     def total_npu_slot_bytes(self) -> int:
         return (
             self.slot_bank_bytes
+            + self.pinned_shared_lane_bytes
             + self.prefill_stage_bank_bytes
             + self.prefill_stage_mapping_bytes
             + self.full_layer_prefill_bank_bytes
@@ -124,6 +130,7 @@ class MoeOffloadMemoryLedger:
             "full_layer_prefill_mapping_bytes": int(
                 self.full_layer_prefill_mapping_bytes
             ),
+            "pinned_shared_lane_bytes": int(self.pinned_shared_lane_bytes),
             "resident_shared_weight_bytes": int(self.resident_shared_weight_bytes),
             "shared_gate_weight_bytes": int(self.shared_gate_weight_bytes),
             "total_npu_slot_bytes": int(self.total_npu_slot_bytes),
@@ -219,6 +226,24 @@ class SlotAddressFingerprint:
     dtype: str
 
 
+@dataclass(frozen=True)
+class FusedSharedLaneLayout:
+    """Logical/physical contract for a fused mix-placement MoE layer.
+
+    The backend emits routed IDs in ``[0, routed_expert_count)`` and appends
+    always-active shared IDs as a suffix. Dynamic slots own only the former;
+    the latter are fixed rows after the dynamic bank.
+    """
+
+    routed_expert_count: int
+    shared_expert_count: int
+    pinned_logical_ids: tuple[int, ...]
+
+    @property
+    def total_logical_expert_count(self) -> int:
+        return int(self.routed_expert_count + self.shared_expert_count)
+
+
 def _slot_address_fingerprint_payload(
     fingerprint: SlotAddressFingerprint,
 ) -> dict[str, object]:
@@ -242,6 +267,7 @@ class MoeOffloadRuntime:
         self._pending_trace_step_by_layer: dict[int, int] = {}
         self._host_store = HostExpertStore()
         self._slot_banks: dict[int, ExpertSlotBank] = {}
+        self._fused_shared_lane_layouts: dict[int, FusedSharedLaneLayout] = {}
         # Physical B2 stage buffers are layout-scoped, not layer-scoped. Layers
         # execute serially through the MoE splitting seam, so equal-layout
         # layers can safely lease the same double buffer when H2D waits for the
@@ -579,13 +605,32 @@ class MoeOffloadRuntime:
 
         start = perf_counter()
         cpu_first_layer = is_cpu_first_layer(layer)
+        w13_weight = getattr(layer, "w13_weight")
+        w2_weight = getattr(layer, "w2_weight")
+        if int(w13_weight.shape[0]) != int(w2_weight.shape[0]):
+            raise ValueError("w13_weight and w2_weight must have the same number of experts")
+        total_logical_experts = int(w13_weight.shape[0])
+        shared_expert_count = _fused_shared_expert_count(layer)
+        if shared_expert_count > total_logical_experts:
+            raise ValueError(
+                "fused shared expert count exceeds materialized expert rows: "
+                f"shared={shared_expert_count}, total={total_logical_experts}"
+            )
+        routed_expert_count = total_logical_experts - shared_expert_count
+        if routed_expert_count <= 0:
+            raise ValueError(
+                "fused mix-placement requires at least one routed expert; "
+                f"total={total_logical_experts}, shared={shared_expert_count}"
+            )
+        pinned_logical_ids = tuple(
+            range(routed_expert_count, total_logical_experts)
+        )
         host_store_report = self._host_store.register_layer(
             layer,
             pin_memory=self.config.should_pin_host_memory,
             clone_tensors=not cpu_first_layer,
+            routed_expert_count=routed_expert_count,
         )
-        w13_weight = getattr(layer, "w13_weight")
-        w2_weight = getattr(layer, "w2_weight")
         self._original_expert_weight_bytes_by_layer[layer_id] = _tensor_nbytes(w13_weight) + _tensor_nbytes(w2_weight)
         self._expert_weight_bytes_by_layer[layer_id] = (
             _tensor_nbytes(w13_weight[0]) + _tensor_nbytes(w2_weight[0])
@@ -597,7 +642,20 @@ class MoeOffloadRuntime:
             tuple(int(dim) for dim in w2_weight.shape[1:]),
             dtype=w13_weight.dtype,
             device=device,
+            pinned_logical_ids=pinned_logical_ids,
         )
+        if pinned_logical_ids:
+            self._slot_banks[layer_id].install_pinned_weights(
+                w13_weight[routed_expert_count:],
+                w2_weight[routed_expert_count:],
+            )
+            self._fused_shared_lane_layouts[layer_id] = FusedSharedLaneLayout(
+                routed_expert_count=routed_expert_count,
+                shared_expert_count=shared_expert_count,
+                pinned_logical_ids=pinned_logical_ids,
+            )
+        else:
+            self._fused_shared_lane_layouts.pop(layer_id, None)
         self._slot_expert_weight_bytes_by_layer[layer_id] = (
             _tensor_nbytes(self._slot_banks[layer_id].w13_slots[0])
             + _tensor_nbytes(self._slot_banks[layer_id].w2_slots[0])
@@ -605,13 +663,18 @@ class MoeOffloadRuntime:
         self._prefill_stage_banks.pop(layer_id, None)
         self._prefill_stage_log2phy_buffers.pop(layer_id, None)
         # Option-2: allocate the persistent log2phy buffer once, fixed address.
-        # Size = num_logical_experts (from the original weight's expert dim).
-        num_logical_experts = int(w13_weight.shape[0])
+        # The backend sees routed IDs plus the fused shared suffix. The stage
+        # planner only receives routed IDs, but the captured gather must be able
+        # to map both ranges through this one stable table.
+        num_logical_experts = total_logical_experts
         self._log2phy_buffers[layer_id] = torch.full(
             (num_logical_experts,),
             fill_value=-1,
             dtype=torch.int32,
             device=device,
+        )
+        self._slot_banks[layer_id].install_pinned_log2phy(
+            self._log2phy_buffers[layer_id]
         )
         self._log2phy_slot_by_expert[layer_id] = {}
         self._invalidate_memory_ledger_cache()
@@ -621,7 +684,57 @@ class MoeOffloadRuntime:
             start=start,
             payload={
                 "host_store": host_store_report.to_jsonable(),
+                "routed_expert_count": int(routed_expert_count),
+                "pinned_shared_expert_count": int(shared_expert_count),
+                "pinned_shared_logical_ids": [
+                    int(expert_id) for expert_id in pinned_logical_ids
+                ],
             },
+        )
+
+    def fused_shared_lane_layout(
+        self,
+        layer_id: int,
+    ) -> FusedSharedLaneLayout | None:
+        return self._fused_shared_lane_layouts.get(int(layer_id))
+
+    def routed_expert_count_for_layer(
+        self,
+        *,
+        layer_id: int,
+        fallback: int,
+    ) -> int:
+        layout = self.fused_shared_lane_layout(layer_id)
+        return (
+            int(layout.routed_expert_count)
+            if layout is not None
+            else int(fallback)
+        )
+
+    def total_logical_expert_count_for_layer(
+        self,
+        *,
+        layer_id: int,
+        fallback: int,
+    ) -> int:
+        layout = self.fused_shared_lane_layout(layer_id)
+        return (
+            int(layout.total_logical_expert_count)
+            if layout is not None
+            else int(fallback)
+        )
+
+    def is_static_residency_regime_for_layer(
+        self,
+        *,
+        layer_id: int,
+        fallback_routed_expert_count: int,
+    ) -> bool:
+        return self.is_static_residency_regime(
+            self.routed_expert_count_for_layer(
+                layer_id=layer_id,
+                fallback=fallback_routed_expert_count,
+            )
         )
 
     def register_resident_shared_weights(
@@ -1042,6 +1155,35 @@ class MoeOffloadRuntime:
         """
         return int(self.config.num_slots) >= int(num_logical_experts)
 
+    def _resolve_fused_shared_counts(
+        self,
+        *,
+        layer_id: int,
+        requested_logical_expert_count: int,
+    ) -> tuple[int, int]:
+        """Return ``(routed_count, total_backend_count)`` for one layer.
+
+        Existing callers describe the set that can be staged, i.e. routed IDs.
+        A fused shared layer additionally needs a mapping entry for its appended
+        shared suffix, so the physical backend count is larger. Accepting the
+        total count as well keeps internal reference paths explicit while still
+        rejecting a mismatched caller rather than silently staging the suffix.
+        """
+
+        requested = int(requested_logical_expert_count)
+        layout = self.fused_shared_lane_layout(layer_id)
+        if layout is None:
+            return requested, requested
+        routed = int(layout.routed_expert_count)
+        total = int(layout.total_logical_expert_count)
+        if requested not in {routed, total}:
+            raise RuntimeError(
+                "fused shared lane logical count mismatch: "
+                f"layer={int(layer_id)} requested={requested} "
+                f"routed={routed} total={total}"
+            )
+        return routed, total
+
     def should_use_b2_wave_prefill(
         self,
         *,
@@ -1122,7 +1264,9 @@ class MoeOffloadRuntime:
             host_experts=len(self._host_store),
             original_expert_weight_bytes=original_bytes,
             host_store_bytes=self._host_store.total_bytes,
-            slot_bank_bytes=sum(slot_bank.total_bytes for slot_bank in self._slot_banks.values()),
+            slot_bank_bytes=sum(
+                slot_bank.dynamic_bytes for slot_bank in self._slot_banks.values()
+            ),
             prefill_stage_bank_count=len(unique_stage_banks),
             prefill_stage_bank_bytes=sum(
                 bank.total_bytes for bank in unique_stage_banks.values()
@@ -1138,6 +1282,9 @@ class MoeOffloadRuntime:
             full_layer_prefill_mapping_bytes=sum(
                 _tensor_nbytes(buffer)
                 for buffer in unique_full_layer_mappings.values()
+            ),
+            pinned_shared_lane_bytes=sum(
+                slot_bank.pinned_bytes for slot_bank in self._slot_banks.values()
             ),
             resident_shared_weight_bytes=sum(
                 self._resident_shared_weight_bytes_by_layer.values()
@@ -1325,11 +1472,15 @@ class MoeOffloadRuntime:
             raise RuntimeError(
                 f"fixed-slot plan must not run on resident layer {layer_id}; use original NPU expert weights"
             )
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=num_logical_experts,
+        )
         unique_active_experts = _dedupe_preserve_order(active_experts)
         _validate_active_expert_ids(
             layer_id=layer_id,
             active_experts=unique_active_experts,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
         )
         if len(unique_active_experts) > self.config.num_slots:
             raise RuntimeError(
@@ -1438,7 +1589,7 @@ class MoeOffloadRuntime:
         mapping = ExpertSlotMapping.from_slot_bank(
             layer_id=layer_id,
             active_experts=unique_active_experts,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=total_logical_experts,
             slot_bank=slot_bank,
             device=device,
         )
@@ -1506,21 +1657,25 @@ class MoeOffloadRuntime:
             raise RuntimeError(
                 f"fixed-slot plan must not run on resident layer {layer_id}; use original NPU expert weights"
             )
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=num_logical_experts,
+        )
         unique_active_experts = _dedupe_preserve_order(active_experts)
         _validate_active_expert_ids(
             layer_id=layer_id,
             active_experts=unique_active_experts,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
         )
         if len(unique_active_experts) > self.config.num_slots:
             raise RuntimeError(
                 f"active expert working set size {len(unique_active_experts)} exceeds num_slots={self.config.num_slots}"
             )
 
-        if int(log2phy.numel()) != int(num_logical_experts):
+        if int(log2phy.numel()) != int(total_logical_experts):
             raise RuntimeError(
                 f"log2phy buffer for layer {layer_id} has size {int(log2phy.numel())}, "
-                f"expected {int(num_logical_experts)}"
+                f"expected {int(total_logical_experts)}"
             )
 
         slot_bank = self._slot_banks.get(layer_id)
@@ -1573,7 +1728,11 @@ class MoeOffloadRuntime:
         )
 
         active_slot_ids: list[int] = []
-        slot_to_expert: list[int | None] = [None] * len(slot_bank.slots)
+        slot_to_expert: list[int | None] = [None] * slot_bank.physical_expert_count
+        for logical_id in slot_bank.pinned_logical_ids:
+            pinned_slot = slot_bank.pinned_slot_for_logical_id(logical_id)
+            assert pinned_slot is not None
+            slot_to_expert[int(pinned_slot)] = int(logical_id)
         for expert_id in unique_active_experts:
             key = ExpertKey(layer_id, int(expert_id))
             slot = slot_bank.lookup(key)
@@ -1803,11 +1962,15 @@ class MoeOffloadRuntime:
             raise RuntimeError(
                 f"ready-slot plan must not run on resident layer {layer_id}; use original NPU expert weights"
             )
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=num_logical_experts,
+        )
         unique_active_experts = _dedupe_preserve_order(active_experts)
         _validate_active_expert_ids(
             layer_id=layer_id,
             active_experts=unique_active_experts,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
         )
         if len(unique_active_experts) > self.config.num_slots:
             raise RuntimeError(
@@ -1824,7 +1987,11 @@ class MoeOffloadRuntime:
             else int(next(self._step_counter))
         )
         missing_experts: list[int] = []
-        slot_to_expert: list[int | None] = [None] * len(slot_bank.slots)
+        slot_to_expert: list[int | None] = [None] * slot_bank.physical_expert_count
+        for logical_id in slot_bank.pinned_logical_ids:
+            pinned_slot = slot_bank.pinned_slot_for_logical_id(logical_id)
+            assert pinned_slot is not None
+            slot_to_expert[int(pinned_slot)] = int(logical_id)
         active_slot_ids: list[int] = []
         for expert_id in unique_active_experts:
             key = ExpertKey(layer_id, int(expert_id))
@@ -1843,7 +2010,7 @@ class MoeOffloadRuntime:
             mapping = ExpertSlotMapping.from_slot_bank(
                 layer_id=layer_id,
                 active_experts=unique_active_experts,
-                num_logical_experts=num_logical_experts,
+                num_logical_experts=total_logical_experts,
                 slot_bank=slot_bank,
                 device=device,
             )
@@ -1894,11 +2061,15 @@ class MoeOffloadRuntime:
             raise RuntimeError(
                 f"prefill stage plan must not run on resident layer {layer_id}"
             )
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=num_logical_experts,
+        )
         unique_active_experts = _dedupe_preserve_order(active_experts)
         _validate_active_expert_ids(
             layer_id=layer_id,
             active_experts=unique_active_experts,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
         )
         if len(unique_active_experts) > self.config.num_slots:
             raise RuntimeError(
@@ -1921,7 +2092,7 @@ class MoeOffloadRuntime:
         log2phy = self._get_prefill_stage_log2phy_buffer(
             layer_id=layer_id,
             buffer_index=int(buffer_index),
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=total_logical_experts,
             device=device,
         )
         step_id = (
@@ -1954,6 +2125,7 @@ class MoeOffloadRuntime:
         if build_log2phy:
             timer = perf_counter() if collect_profile else 0.0
             log2phy.fill_(-1)
+            stage_bank.install_pinned_log2phy(log2phy)
             _mark("log2phy_fill", timer)
         for slot_id, expert_id in enumerate(unique_active_experts):
             key = ExpertKey(layer_id, int(expert_id))
@@ -2029,7 +2201,11 @@ class MoeOffloadRuntime:
         _mark("ready_event", timer)
 
         timer = perf_counter() if collect_profile else 0.0
-        slot_to_expert: list[int | None] = [None] * len(stage_bank.slots)
+        slot_to_expert: list[int | None] = [None] * stage_bank.physical_expert_count
+        for logical_id in stage_bank.pinned_logical_ids:
+            pinned_slot = stage_bank.pinned_slot_for_logical_id(logical_id)
+            assert pinned_slot is not None
+            slot_to_expert[int(pinned_slot)] = int(logical_id)
         for slot_id, expert_id in enumerate(unique_active_experts):
             slot_to_expert[int(slot_id)] = int(expert_id)
         mapping = ExpertSlotMapping(
@@ -2101,12 +2277,15 @@ class MoeOffloadRuntime:
             )
 
         layer_id = int(layer_id)
-        num_logical_experts = int(num_logical_experts)
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=num_logical_experts,
+        )
         if self.is_resident_layer(layer_id):
             raise RuntimeError(
                 f"full-layer prefill plan must not run on resident layer {layer_id}"
             )
-        if num_logical_experts <= 0:
+        if routed_expert_count <= 0:
             raise ValueError("num_logical_experts must be greater than 0")
 
         template_bank = self._slot_banks.get(layer_id)
@@ -2115,26 +2294,26 @@ class MoeOffloadRuntime:
                 f"layer {layer_id} is not registered for fixed-slot execution"
             )
         layer_buffer = self._host_store.get_layer_buffer(layer_id)
-        if int(layer_buffer.num_experts) != num_logical_experts:
+        if int(layer_buffer.num_experts) != routed_expert_count:
             raise RuntimeError(
                 f"host expert count for layer {layer_id} is "
-                f"{layer_buffer.num_experts}, expected {num_logical_experts}"
+                f"{layer_buffer.num_experts}, expected {routed_expert_count}"
             )
 
         pool_key = self._full_layer_prefill_pool_key(
             template_bank,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
         )
         pool_reused = pool_key in self._full_layer_prefill_pool
         bank = self._get_full_layer_prefill_bank(
             layer_id=layer_id,
             template_bank=template_bank,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=routed_expert_count,
             pool_key=pool_key,
         )
         log2phy = self._get_full_layer_prefill_log2phy_buffer(
             pool_key=pool_key,
-            num_logical_experts=num_logical_experts,
+            num_logical_experts=total_logical_experts,
             device=device,
         )
         step_id = (
@@ -2143,7 +2322,7 @@ class MoeOffloadRuntime:
             else int(next(self._step_counter))
         )
 
-        for expert_id in range(num_logical_experts):
+        for expert_id in range(routed_expert_count):
             bank.assign_transient_slot(
                 expert_id,
                 ExpertKey(layer_id, expert_id),
@@ -2152,22 +2331,26 @@ class MoeOffloadRuntime:
 
         stage_start = perf_counter()
         try:
-            bank.w13_slots.copy_(layer_buffer.w13, non_blocking=False)
-            bank.w2_slots.copy_(layer_buffer.w2, non_blocking=False)
+            bank.w13_slots[:routed_expert_count].copy_(layer_buffer.w13, non_blocking=False)
+            bank.w2_slots[:routed_expert_count].copy_(layer_buffer.w2, non_blocking=False)
+            bank.copy_pinned_weights_from(template_bank)
         except Exception:
-            for slot_id in range(num_logical_experts):
+            for slot_id in range(routed_expert_count):
                 bank.clear_slot(slot_id, force=True)
             raise
-        for slot_id in range(num_logical_experts):
+        for slot_id in range(routed_expert_count):
             bank.mark_ready(slot_id)
         stage_ms = (perf_counter() - stage_start) * 1000.0
 
-        all_experts = tuple(range(num_logical_experts))
+        all_experts = tuple(range(routed_expert_count))
+        slot_to_expert: list[int | None] = list(all_experts)
+        for logical_id in bank.pinned_logical_ids:
+            slot_to_expert.append(int(logical_id))
         mapping = ExpertSlotMapping(
             layer_id=layer_id,
             active_experts=all_experts,
             logical_to_physical=log2phy,
-            slot_to_expert=all_experts,
+            slot_to_expert=tuple(slot_to_expert),
             active_slot_ids=all_experts,
         )
         prepared = PreparedSlotWeights.from_slot_bank(
@@ -2176,7 +2359,9 @@ class MoeOffloadRuntime:
         )
         payload = {
             "execution_mode": "reference_full_layer",
-            "num_logical_experts": num_logical_experts,
+            "num_logical_experts": total_logical_experts,
+            "routed_expert_count": routed_expert_count,
+            "pinned_shared_expert_count": len(bank.pinned_logical_ids),
             "physical_expert_count": int(prepared.physical_expert_count),
             "h2d_bytes": int(layer_buffer.total_bytes),
             "stage_ms": round(stage_ms, 3),
@@ -2233,8 +2418,10 @@ class MoeOffloadRuntime:
                     tuple(int(dim) for dim in template_bank.w2_slots.shape[1:]),
                     dtype=template_bank.w13_slots.dtype,
                     device=template_bank.w13_slots.device,
+                    pinned_logical_ids=template_bank.pinned_logical_ids,
                 )
             )
+            banks[-1].copy_pinned_weights_from(template_bank)
             self._invalidate_memory_ledger_cache()
             hbm_after = self._npu_hbm_snapshot(template_bank.w13_slots.device)
             self._record_profile_event(
@@ -2268,6 +2455,7 @@ class MoeOffloadRuntime:
             str(template_bank.w13_slots.device),
             str(template_bank.w13_slots.dtype),
             int(num_logical_experts),
+            tuple(int(expert_id) for expert_id in template_bank.pinned_logical_ids),
             tuple(int(dim) for dim in template_bank.w13_slots.shape[1:]),
             tuple(int(dim) for dim in template_bank.w2_slots.shape[1:]),
             tuple(int(stride) for stride in template_bank.w13_slots[0].stride()),
@@ -2294,6 +2482,7 @@ class MoeOffloadRuntime:
             tuple(int(dim) for dim in template_bank.w2_slots.shape[1:]),
             dtype=template_bank.w13_slots.dtype,
             device=template_bank.w13_slots.device,
+            pinned_logical_ids=template_bank.pinned_logical_ids,
         )
         self._full_layer_prefill_pool[pool_key] = bank
         self._invalidate_memory_ledger_cache()
@@ -2304,7 +2493,7 @@ class MoeOffloadRuntime:
             start=allocation_start,
             payload={
                 "bank_bytes": int(bank.total_bytes),
-                "physical_expert_count": int(num_logical_experts),
+                "physical_expert_count": int(bank.physical_expert_count),
                 "hbm_before": hbm_before,
                 "hbm_after": hbm_after,
             },
@@ -2346,6 +2535,8 @@ class MoeOffloadRuntime:
             str(template_bank.w13_slots.device),
             str(template_bank.w13_slots.dtype),
             len(template_bank.slots),
+            tuple(int(expert_id) for expert_id in template_bank.pinned_logical_ids),
+            tuple(int(expert_id) for expert_id in template_bank.pinned_logical_ids),
             tuple(int(dim) for dim in template_bank.w13_slots.shape[1:]),
             tuple(int(dim) for dim in template_bank.w2_slots.shape[1:]),
             tuple(int(stride) for stride in template_bank.w13_slots.stride()),
@@ -2521,14 +2712,22 @@ class MoeOffloadRuntime:
         self._lock_graph_slot_addresses(layer_id)
         from vllm_moe_offload_ascend.moe_offload.slot_mapping import ExpertSlotMapping
 
+        slot_to_expert: list[int | None] = [
+            int(slot.expert_key.expert_id)
+            if slot.expert_key is not None
+            else None
+            for slot in slot_bank.slots
+        ]
+        for logical_id in slot_bank.pinned_logical_ids:
+            pinned_slot = slot_bank.pinned_slot_for_logical_id(logical_id)
+            assert pinned_slot is not None
+            slot_to_expert.append(int(logical_id))
+
         mapping = ExpertSlotMapping(
             layer_id=layer_id,
             active_experts=(),
             logical_to_physical=buf,
-            slot_to_expert=tuple(
-                int(slot.expert_key.expert_id) if slot.expert_key is not None else None
-                for slot in slot_bank.slots
-            ),
+            slot_to_expert=tuple(slot_to_expert),
             active_slot_ids=(),
         )
         return PreparedSlotWeights.from_slot_bank(slot_bank=slot_bank, mapping=mapping)
@@ -2638,8 +2837,11 @@ class MoeOffloadRuntime:
         buf = self._log2phy_buffers.get(layer_id)
         if buf is None:
             return False
-        num_logical_experts = int(buf.numel())
-        if not self.is_static_residency_regime(num_logical_experts):
+        routed_expert_count, total_logical_experts = self._resolve_fused_shared_counts(
+            layer_id=layer_id,
+            requested_logical_expert_count=int(buf.numel()),
+        )
+        if not self.is_static_residency_regime(routed_expert_count):
             self._record_profile_event(
                 "skip_full_residency_slot_plan",
                 layer_id=layer_id,
@@ -2647,14 +2849,15 @@ class MoeOffloadRuntime:
                 payload={
                     "reason": "regime_b_num_slots_lt_logical_experts",
                     "num_slots": int(self.config.num_slots),
-                    "num_logical_experts": int(num_logical_experts),
+                    "num_logical_experts": int(total_logical_experts),
+                    "routed_expert_count": int(routed_expert_count),
                 },
             )
             return False
         self.stage_fixed_slot_plan(
             layer_id=layer_id,
-            active_experts=tuple(range(num_logical_experts)),
-            num_logical_experts=num_logical_experts,
+            active_experts=tuple(range(routed_expert_count)),
+            num_logical_experts=total_logical_experts,
         )
         return True
 
@@ -2735,6 +2938,23 @@ class MoeOffloadRuntime:
 
 def _tensor_nbytes(tensor: torch.Tensor) -> int:
     return int(tensor.numel()) * int(tensor.element_size())
+
+
+def _fused_shared_expert_count(layer: torch.nn.Module) -> int:
+    """Return the appended shared suffix size for a mix-placement layer."""
+
+    if not bool(getattr(layer, "mix_placement", False)):
+        return 0
+    try:
+        count = int(getattr(layer, "n_shared_experts", 0) or 0)
+    except (TypeError, ValueError):
+        count = 0
+    if count <= 0:
+        raise ValueError(
+            "mix_placement is enabled but layer.n_shared_experts is not a "
+            "positive integer"
+        )
+    return count
 
 
 def _module_parameter_bytes(module: object | None) -> dict[int, int]:

--- a/vllm_moe_offload_ascend/moe_offload/slot_bank.py
+++ b/vllm_moe_offload_ascend/moe_offload/slot_bank.py
@@ -85,11 +85,34 @@ class ExpertSlotBank:
         *,
         dtype: torch.dtype,
         device: torch.device,
+        pinned_logical_ids: tuple[int, ...] = (),
     ) -> None:
         if num_slots <= 0:
             raise ValueError("num_slots must be greater than 0")
-        self.w13_slots = torch.empty((num_slots, *w13_shape), dtype=dtype, device=device)
-        self.w2_slots = torch.empty((num_slots, *w2_shape), dtype=dtype, device=device)
+        normalized_pinned = tuple(int(expert_id) for expert_id in pinned_logical_ids)
+        if len(set(normalized_pinned)) != len(normalized_pinned):
+            raise ValueError("pinned logical expert ids must be unique")
+        if any(expert_id < 0 for expert_id in normalized_pinned):
+            raise ValueError("pinned logical expert ids must be non-negative")
+
+        # A fused/mix-placement layer exposes shared experts in the same backend
+        # weight tensor as routed experts. Keep those rows in a stable suffix of
+        # the physical tensor, while ``slots`` continues to describe *only* the
+        # dynamic routed cache. This makes it impossible for LRU/victim logic to
+        # evict a pinned shared expert by accident.
+        self.num_dynamic_slots = int(num_slots)
+        self.pinned_logical_ids = normalized_pinned
+        self._pinned_slot_by_logical_id = {
+            logical_id: int(num_slots) + offset
+            for offset, logical_id in enumerate(normalized_pinned)
+        }
+        physical_expert_count = int(num_slots) + len(normalized_pinned)
+        self.w13_slots = torch.empty(
+            (physical_expert_count, *w13_shape), dtype=dtype, device=device
+        )
+        self.w2_slots = torch.empty(
+            (physical_expert_count, *w2_shape), dtype=dtype, device=device
+        )
         self.slots = [
             ExpertSlot(
                 slot_id=slot_id,
@@ -100,6 +123,90 @@ class ExpertSlotBank:
         ]
         self._resident: dict[ExpertKey, int] = {}
         self._resident_by_expert_id: dict[int, int] = {}
+
+    @property
+    def physical_expert_count(self) -> int:
+        return int(self.w13_slots.shape[0])
+
+    @property
+    def pinned_slot_ids(self) -> tuple[int, ...]:
+        return tuple(
+            int(self._pinned_slot_by_logical_id[logical_id])
+            for logical_id in self.pinned_logical_ids
+        )
+
+    @property
+    def dynamic_bytes(self) -> int:
+        return _tensor_nbytes(self.w13_slots[: self.num_dynamic_slots]) + _tensor_nbytes(
+            self.w2_slots[: self.num_dynamic_slots]
+        )
+
+    @property
+    def pinned_bytes(self) -> int:
+        return _tensor_nbytes(self.w13_slots[self.num_dynamic_slots :]) + _tensor_nbytes(
+            self.w2_slots[self.num_dynamic_slots :]
+        )
+
+    def pinned_slot_for_logical_id(self, logical_id: int) -> int | None:
+        return self._pinned_slot_by_logical_id.get(int(logical_id))
+
+    def install_pinned_weights(
+        self,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+    ) -> None:
+        """Copy always-resident shared rows into the immutable suffix."""
+
+        pinned_count = len(self.pinned_logical_ids)
+        if pinned_count == 0:
+            if w13.numel() or w2.numel():
+                raise ValueError("cannot install pinned weights into a routed-only bank")
+            return
+        expected_w13 = tuple(int(dim) for dim in self.w13_slots.shape[1:])
+        expected_w2 = tuple(int(dim) for dim in self.w2_slots.shape[1:])
+        if (
+            int(w13.shape[0]) != pinned_count
+            or tuple(int(dim) for dim in w13.shape[1:]) != expected_w13
+            or int(w2.shape[0]) != pinned_count
+            or tuple(int(dim) for dim in w2.shape[1:]) != expected_w2
+        ):
+            raise ValueError(
+                "pinned shared weight layout does not match slot bank: "
+                f"w13={tuple(w13.shape)} expected=({pinned_count}, {expected_w13}); "
+                f"w2={tuple(w2.shape)} expected=({pinned_count}, {expected_w2})"
+            )
+        # Weight registration must not attach the permanent slot storage to the
+        # checkpoint Parameter's autograd graph. Inference weights may still be
+        # Parameters even though the runtime never differentiates them.
+        with torch.no_grad():
+            self.w13_slots[self.num_dynamic_slots :].copy_(w13, non_blocking=False)
+            self.w2_slots[self.num_dynamic_slots :].copy_(w2, non_blocking=False)
+
+    def copy_pinned_weights_from(self, source: "ExpertSlotBank") -> None:
+        """Clone a compatible pinned lane into a temporary prefill bank."""
+
+        if self.pinned_logical_ids != source.pinned_logical_ids:
+            raise ValueError("cannot copy pinned weights across different logical layouts")
+        if not self.pinned_logical_ids:
+            return
+        with torch.no_grad():
+            self.w13_slots[self.num_dynamic_slots :].copy_(
+                source.w13_slots[source.num_dynamic_slots :], non_blocking=False
+            )
+            self.w2_slots[self.num_dynamic_slots :].copy_(
+                source.w2_slots[source.num_dynamic_slots :], non_blocking=False
+            )
+
+    def install_pinned_log2phy(self, log2phy: torch.Tensor) -> None:
+        """Write immutable shared logical->physical entries into a mapping."""
+
+        for logical_id, slot_id in self._pinned_slot_by_logical_id.items():
+            if logical_id >= int(log2phy.numel()):
+                raise ValueError(
+                    "log2phy does not cover pinned logical expert "
+                    f"{logical_id}; size={int(log2phy.numel())}"
+                )
+            log2phy[int(logical_id)] = int(slot_id)
 
     def allocate_for(self, expert_key: ExpertKey, *, step_id: int) -> ExpertSlot:
         if expert_key in self._resident:

--- a/vllm_moe_offload_ascend/moe_offload/slot_mapping.py
+++ b/vllm_moe_offload_ascend/moe_offload/slot_mapping.py
@@ -76,8 +76,17 @@ class ExpertSlotMapping:
             dtype=dtype,
             device=device,
         )
-        slot_to_expert: list[int | None] = [None] * len(slot_bank.slots)
+        slot_to_expert: list[int | None] = [None] * slot_bank.physical_expert_count
         active_slot_ids: list[int] = []
+
+        # Fused/mix-placement shared experts occupy immutable physical suffix
+        # rows. They are not part of the dynamic active set, but their logical
+        # IDs are present in every backend top-k and must map on every call.
+        slot_bank.install_pinned_log2phy(logical_to_physical)
+        for logical_id in slot_bank.pinned_logical_ids:
+            pinned_slot = slot_bank.pinned_slot_for_logical_id(logical_id)
+            assert pinned_slot is not None
+            slot_to_expert[int(pinned_slot)] = int(logical_id)
 
         for expert_id in unique_active_experts:
             if expert_id < 0 or expert_id >= num_logical_experts:
@@ -173,6 +182,6 @@ class PreparedSlotWeights:
             w1=slot_bank.w13_slots,
             w2=slot_bank.w2_slots,
             log2phy=mapping.logical_to_physical,
-            physical_expert_count=len(slot_bank.slots),
+            physical_expert_count=slot_bank.physical_expert_count,
             mapping=mapping,
         )

--- a/vllm_moe_offload_ascend/ops/fused_moe/moe_offload_stage_op.py
+++ b/vllm_moe_offload_ascend/ops/fused_moe/moe_offload_stage_op.py
@@ -195,6 +195,28 @@ def _moe_offload_stage_impl(
 
     runtime = get_moe_offload_runtime()
     layer_id = int(layer_id)
+    routed_count_fn = getattr(runtime, "routed_expert_count_for_layer", None)
+    total_count_fn = getattr(runtime, "total_logical_expert_count_for_layer", None)
+    routed_expert_count = (
+        int(
+            routed_count_fn(
+                layer_id=layer_id,
+                fallback=int(num_logical_experts),
+            )
+        )
+        if callable(routed_count_fn)
+        else int(num_logical_experts)
+    )
+    total_logical_experts = (
+        int(
+            total_count_fn(
+                layer_id=layer_id,
+                fallback=int(num_logical_experts),
+            )
+        )
+        if callable(total_count_fn)
+        else int(num_logical_experts)
+    )
 
     # During capture we must not perform host sync / conditional H2D. In the
     # canonical flow the captured graph only reads the fixed slot tensors + the
@@ -225,7 +247,18 @@ def _moe_offload_stage_impl(
     # later step's expert that maps to -1 makes the captured gather read slot[-1]
     # (MTE DDR out-of-range). The seam must therefore be a transparent no-op in
     # Regime A; it owns staging only in Regime B (num_slots < n).
-    if runtime.is_static_residency_regime(int(num_logical_experts)):
+    static_for_layer = getattr(runtime, "is_static_residency_regime_for_layer", None)
+    is_static = (
+        bool(
+            static_for_layer(
+                layer_id=layer_id,
+                fallback_routed_expert_count=routed_expert_count,
+            )
+        )
+        if callable(static_for_layer)
+        else bool(runtime.is_static_residency_regime(routed_expert_count))
+    )
+    if is_static:
         if os.environ.get("SEW_SEAM_PROBE"):
             _PROBE_CALLS["eager_passthrough"] += 1
             print(
@@ -264,7 +297,7 @@ def _moe_offload_stage_impl(
     flat_topk_ids = topk_ids.detach().reshape(-1).to("cpu", non_blocking=False)
     token_counts_by_expert, flat_topk_id_list = _count_active_experts_from_cpu_topk(
         flat_topk_ids,
-        num_logical_experts=int(num_logical_experts),
+        num_logical_experts=routed_expert_count,
     )
     active_experts = tuple(sorted(token_counts_by_expert))
 
@@ -421,7 +454,7 @@ def _moe_offload_stage_impl(
     runtime.stage_fixed_slot_plan(
         layer_id=layer_id,
         active_experts=active_experts,
-        num_logical_experts=int(num_logical_experts),
+        num_logical_experts=total_logical_experts,
     )
     if _probe:
         torch.npu.synchronize()

--- a/vllm_moe_offload_ascend/ops/fused_moe/moe_router_op.py
+++ b/vllm_moe_offload_ascend/ops/fused_moe/moe_router_op.py
@@ -38,8 +38,8 @@ First-version constraints (see design doc decisions):
   - ``custom_routing_function`` MUST be None (a Callable cannot cross an op
     boundary). Callers with a custom routing function fall back to the
     monolithic ``super().forward()`` path.
-  - mirrors the apply-path call exactly: ``mix_placement=False``,
-    ``num_shared_experts=0`` (the apply-path select_experts call passes neither).
+  - mirrors the apply-path call exactly, including fused/mix-placement shared
+    suffixes when the materialized layer enables them.
 
 Current integration: the explicit router core and the layer-name indirect
 router are registered for the SEW router -> stage -> MLP dataplane. The seam
@@ -81,6 +81,8 @@ def _moe_router_impl(
     routed_scaling_factor: float,
     e_score_correction_bias: torch.Tensor | None,
     num_experts: int,
+    mix_placement: bool = False,
+    num_shared_experts: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run expert selection exactly as the apply-path does, returning
     ``(topk_weights, topk_ids)``.
@@ -116,6 +118,9 @@ def _moe_router_impl(
         routed_scaling_factor=routed_scaling_factor,
         e_score_correction_bias=e_score_correction_bias,
         num_experts=num_experts,
+        mix_placement=bool(mix_placement),
+        num_logical_experts=int(num_experts),
+        num_shared_experts=int(num_shared_experts),
     )
     return topk_weights, topk_ids
 
@@ -132,9 +137,11 @@ def _moe_router_fake(
     routed_scaling_factor: float,
     e_score_correction_bias: torch.Tensor | None,
     num_experts: int,
+    mix_placement: bool = False,
+    num_shared_experts: int = 0,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    # Trace-time shape/dtype proxy. The apply-path call passes mix_placement=False
-    # and num_shared_experts=0, so both outputs are (num_tokens, top_k).
+    # Trace-time shape/dtype proxy. Fused mix-placement appends one shared pair
+    # per shared expert to the routed top-k suffix.
     #   - topk_weights: real _native_select_experts casts to hidden_states.dtype
     #     (experts_selector.py line ~322: `topk_weights = topk_weights.to(x.dtype)`).
     #     Using router_logits.dtype was wrong for indirect-router models where the
@@ -143,10 +150,14 @@ def _moe_router_fake(
     #   - topk_ids: int32 selected logical-expert ids.
     num_tokens = hidden_states.shape[0]
     topk_weights = torch.empty(
-        (num_tokens, top_k), dtype=hidden_states.dtype, device=hidden_states.device
+        (num_tokens, top_k + (int(num_shared_experts) if mix_placement else 0)),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
     )
     topk_ids = torch.empty(
-        (num_tokens, top_k), dtype=torch.int32, device=hidden_states.device
+        (num_tokens, top_k + (int(num_shared_experts) if mix_placement else 0)),
+        dtype=torch.int32,
+        device=hidden_states.device,
     )
     return topk_weights, topk_ids
 
@@ -220,6 +231,7 @@ def _moe_router_indirect_impl(
         router_logits, _ = gate(hidden_states)
 
     num_shared_experts = getattr(layer, "n_shared_experts", 0) or 0
+    mix_placement = bool(getattr(layer, "mix_placement", False))
     num_logical_experts = get_moe_num_logical_experts(
         layer,
         layer.moe_config.num_experts,
@@ -248,6 +260,8 @@ def _moe_router_indirect_impl(
         routed_scaling_factor=routed_scaling_factor,
         e_score_correction_bias=layer.e_score_correction_bias,
         num_experts=num_logical_experts,
+        mix_placement=mix_placement,
+        num_shared_experts=num_shared_experts,
     )
     if os.getenv("VLLM_ASCEND_MOE_ROUTER_PARITY_PATH") and _capture_state() != "True":
         from vllm_moe_offload_ascend.moe_offload.router_parity import (
@@ -290,6 +304,8 @@ def _moe_router_indirect_fake(
         ),
         e_score_correction_bias=layer.e_score_correction_bias,
         num_experts=layer.moe_config.num_experts,
+        mix_placement=bool(getattr(layer, "mix_placement", False)),
+        num_shared_experts=int(getattr(layer, "n_shared_experts", 0) or 0),
     )
 
 

--- a/vllm_moe_offload_ascend/patches/patch_fused_moe.py
+++ b/vllm_moe_offload_ascend/patches/patch_fused_moe.py
@@ -25,8 +25,23 @@ import sys
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
+from threading import RLock
 from time import perf_counter
 from typing import Any
+
+
+_MIX_PLACEMENT_AITER_INIT_LOCK = RLock()
+
+
+def _summarize_fused_shared_ids(shared_ids: Any) -> list[int]:
+    """Return a bounded eager-only summary for a fused router suffix."""
+
+    import torch
+
+    if not isinstance(shared_ids, torch.Tensor):
+        return []
+    values = shared_ids.detach().to(device="cpu", dtype=torch.int64).flatten().tolist()
+    return sorted({int(value) for value in values})
 
 
 def _ascend_device_op_is_initializing() -> bool:
@@ -1742,9 +1757,31 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             device=shared_ids.device,
         ).view(1, shared_count).expand_as(shared_ids)
         if not bool(torch.equal(shared_ids, expected_shared_ids)):
+            capturing = _is_torch_compile_tracing() or _is_current_graph_capturing()
+            actual_suffix_ids: list[int] | str = "unavailable_during_capture"
+            if not capturing:
+                try:
+                    actual_suffix_ids = _summarize_fused_shared_ids(shared_ids)
+                except Exception as exc:
+                    actual_suffix_ids = f"unavailable:{type(exc).__name__}"
+            runtime._record_profile_event(
+                "fused_shared_router_suffix_mismatch",
+                layer_id=int(offload.layer_id),
+                start=perf_counter(),
+                payload={
+                    "topk_width": int(topk_ids.shape[1]),
+                    "shared_width": shared_count,
+                    "routed_expert_count": routed_count,
+                    "total_logical_expert_count": total_count,
+                    "expected_shared_ids": list(range(routed_count, total_count)),
+                    "actual_suffix_ids": actual_suffix_ids,
+                    "capturing": bool(capturing),
+                },
+            )
             raise RuntimeError(
                 "fused shared B2 expected appended pinned shared IDs "
-                f"[{routed_count}, {total_count}), but router suffix differs"
+                f"[{routed_count}, {total_count}), but router suffix differs; "
+                f"topk_width={int(topk_ids.shape[1])} actual_suffix_ids={actual_suffix_ids}"
             )
 
         routed_input = replace(
@@ -1754,13 +1791,23 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
         )
         routed_profile = dict(control_profile)
         routed_profile["pair_offsets_by_expert"] = None
-        routed_result = self._run_b2_wave_prefill(
-            fused_experts_input=routed_input,
-            active_experts=tuple(sorted(int(expert_id) for expert_id in token_counts)),
-            token_counts=token_counts,
-            before_dispatch_evt=before_dispatch_evt,
-            control_profile=routed_profile,
-        )
+        dispatcher = getattr(self, "token_dispatcher", None)
+        if dispatcher is None or not hasattr(dispatcher, "top_k"):
+            raise RuntimeError(
+                "fused shared B2 requires a token dispatcher with a mutable top_k"
+            )
+        original_dispatch_top_k = int(dispatcher.top_k)
+        dispatcher.top_k = int(routed_input.topk_ids.shape[1])
+        try:
+            routed_result = self._run_b2_wave_prefill(
+                fused_experts_input=routed_input,
+                active_experts=tuple(sorted(int(expert_id) for expert_id in token_counts)),
+                token_counts=token_counts,
+                before_dispatch_evt=before_dispatch_evt,
+                control_profile=routed_profile,
+            )
+        finally:
+            dispatcher.top_k = original_dispatch_top_k
         if routed_result is None:
             raise RuntimeError("fused shared B2 routed executor produced no result")
 
@@ -1788,12 +1835,6 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
         # path keeps that value at the model's routed top-k, while this native
         # call deliberately contains only the pinned shared suffix. Set it for
         # this call only, then restore it before the next routed wave.
-        dispatcher = getattr(self, "token_dispatcher", None)
-        if dispatcher is None or not hasattr(dispatcher, "top_k"):
-            raise RuntimeError(
-                "fused shared B2 requires a token dispatcher with a mutable top_k"
-            )
-        original_dispatch_top_k = int(dispatcher.top_k)
         dispatcher.top_k = shared_count
         try:
             shared_result = original_fused_experts(self, shared_input)
@@ -3428,8 +3469,119 @@ def _wrap_setup_moe_comm_method(_comm: Any, original_setup_moe_comm_method: Call
 
 
 def _patch_fused_moe_runtime_hooks(_fused_moe: Any) -> None:
+    _patch_ascend_mix_placement_aiter_compat(_fused_moe)
     _patch_unquantized_moe_method(_fused_moe)
     _patch_ascend_moe_runner(_fused_moe)
+
+
+def _ascend_mix_placement_enabled() -> bool:
+    """Return whether the active Ascend backend fuses shared expert rows."""
+
+    try:
+        from vllm_ascend.ascend_config import get_ascend_config
+
+        return bool(getattr(get_ascend_config(), "mix_placement", False))
+    except Exception:
+        return False
+
+
+def _patch_ascend_mix_placement_aiter_compat(_fused_moe: Any) -> None:
+    """Keep Ascend's mix-placement shim from allocating ROCm CUDA buffers.
+
+    The pinned vLLM-Ascend runner temporarily reports the ROCm AIter shared
+    expert feature as enabled while constructing a mix-placement model. That
+    preserves upstream model layout selection, but the parent ``FusedMoE``
+    constructor then attempts to allocate its AIter metadata on ``cuda``.
+    Ascend has a separate router and dispatch path, so suppress AIter only for
+    the parent constructor, while retaining the backend's model-level layout
+    choice and restoring its shim immediately afterward.
+    """
+
+    cls = getattr(_fused_moe, "AscendFusedMoE", None)
+    if cls is None or getattr(cls, "_latchmoe_mix_placement_aiter_patch", False):
+        return
+
+    original_init = cls.__init__
+
+    def __init__(self, *args, **kwargs):
+        shared_count = kwargs.get("n_shared_experts", 0)
+        try:
+            shared_count = int(shared_count or 0)
+        except (TypeError, ValueError):
+            shared_count = 0
+        if shared_count <= 0 or not _ascend_mix_placement_enabled():
+            return original_init(self, *args, **kwargs)
+
+        try:
+            from vllm._aiter_ops import rocm_aiter_ops
+        except Exception:
+            return original_init(self, *args, **kwargs)
+
+        original_shared_enabled = getattr(
+            rocm_aiter_ops,
+            "is_fusion_moe_shared_experts_enabled",
+            None,
+        )
+        original_fused_enabled = getattr(
+            rocm_aiter_ops,
+            "is_fused_moe_enabled",
+            None,
+        )
+        if not callable(original_shared_enabled) or not callable(original_fused_enabled):
+            return original_init(self, *args, **kwargs)
+
+        def _disabled() -> bool:
+            return False
+
+        # The Ascend runner changes these process-global probes to make
+        # upstream models pass shared rows to FusedMoE. Model construction is
+        # serialized per EngineCore; the lock also keeps restoration atomic in
+        # tests and alternative launchers.
+        with _MIX_PLACEMENT_AITER_INIT_LOCK:
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = _disabled
+            rocm_aiter_ops.is_fused_moe_enabled = _disabled
+            try:
+                result = original_init(self, *args, **kwargs)
+            finally:
+                rocm_aiter_ops.is_fusion_moe_shared_experts_enabled = (
+                    original_shared_enabled
+                )
+                rocm_aiter_ops.is_fused_moe_enabled = original_fused_enabled
+
+        self._latchmoe_mix_placement_aiter_suppressed = True
+        moe_config = getattr(self, "moe_config", None)
+        routed_top_k = getattr(moe_config, "experts_per_token", None)
+        if moe_config is not None and routed_top_k is not None:
+            try:
+                routed_top_k = int(routed_top_k)
+            except (TypeError, ValueError):
+                routed_top_k = 0
+            if routed_top_k > 0:
+                total_top_k = routed_top_k + shared_count
+                # AllGather derives active_num from its persistent dispatcher
+                # rather than the input width. The upstream backend leaves this
+                # at routed top-k even though select_experts appends shared
+                # pairs, so install the full native width before the comm
+                # method is used. B2 temporarily narrows it per split below.
+                moe_config.experts_per_token = total_top_k
+                setup_moe_comm_method = getattr(_fused_moe, "setup_moe_comm_method", None)
+                if callable(setup_moe_comm_method):
+                    setup_moe_comm_method(moe_config)
+                self._latchmoe_mix_placement_dispatch_top_k = total_top_k
+        if not getattr(cls, "_latchmoe_mix_placement_aiter_announced", False):
+            print(
+                "LATCHMOE_BACKEND_COMPAT "
+                "mix_placement_aiter=disabled_for_ascend "
+                f"dispatch_top_k={getattr(self, '_latchmoe_mix_placement_dispatch_top_k', 'unchanged')}",
+                flush=True,
+            )
+            cls._latchmoe_mix_placement_aiter_announced = True
+        return result
+
+    __init__._latchmoe_mix_placement_aiter_patch = True
+    __init__.__wrapped__ = original_init
+    cls.__init__ = __init__
+    cls._latchmoe_mix_placement_aiter_patch = True
 
 
 def _ondemand_stage_enabled() -> bool:
@@ -3589,6 +3741,7 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
 
     def select_experts(*args, **kwargs):
         layer_id = getattr(layer_context, "layer_id", None)
+        layer = getattr(layer_context, "layer", None)
         if layer_id is not None:
             injected = moe_seam_inject.peek_injected_topk(int(layer_id))
             if injected is not None:
@@ -3605,26 +3758,73 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
                     and not _is_torch_compile_tracing()
                     and not _is_current_graph_capturing()
                 ):
+                    # The native Ascend apply path omits mix-placement
+                    # arguments even though the materialized expert bank has
+                    # an immutable shared suffix. Reconstruct those arguments
+                    # from the registered lane so the diagnostic compares like
+                    # with like: 6 routed + 2 shared columns, not 6 vs 8.
+                    native_kwargs = kwargs
+                    runtime = get_moe_offload_runtime()
+                    layout_fn = getattr(runtime, "fused_shared_lane_layout", None)
+                    fused_layout = (
+                        layout_fn(int(layer_id)) if callable(layout_fn) else None
+                    )
+                    if (
+                        fused_layout is not None
+                        and not bool(kwargs.get("mix_placement", False))
+                    ):
+                        native_kwargs = dict(kwargs)
+                        native_kwargs.update(
+                            mix_placement=True,
+                            num_logical_experts=int(
+                                fused_layout.routed_expert_count
+                            ),
+                            num_shared_experts=int(
+                                fused_layout.shared_expert_count
+                            ),
+                        )
                     native_weights, native_ids = original_select_experts(
                         *args,
-                        **kwargs,
+                        **native_kwargs,
                     )
                     injected_weights, injected_ids = injected
-                    id_mismatch_count = int(
-                        torch.count_nonzero(native_ids != injected_ids).item()
+                    ids_same_shape = tuple(native_ids.shape) == tuple(
+                        injected_ids.shape
                     )
-                    weight_diff = (
-                        native_weights.float() - injected_weights.float()
-                    ).abs()
+                    weights_same_shape = tuple(native_weights.shape) == tuple(
+                        injected_weights.shape
+                    )
+                    ids_equal = ids_same_shape and bool(
+                        torch.equal(native_ids, injected_ids)
+                    )
+                    weights_equal = weights_same_shape and bool(
+                        torch.equal(native_weights, injected_weights)
+                    )
+                    id_mismatch_count = (
+                        int(torch.count_nonzero(native_ids != injected_ids).item())
+                        if ids_same_shape
+                        else -1
+                    )
+                    if weights_same_shape:
+                        weight_diff = (
+                            native_weights.float() - injected_weights.float()
+                        ).abs()
+                        weight_max_abs: float | str = float(weight_diff.max().item())
+                        weight_mean_abs: float | str = float(weight_diff.mean().item())
+                    else:
+                        weight_max_abs = "shape_mismatch"
+                        weight_mean_abs = "shape_mismatch"
                     print(
                         "SEW_ROUTER_COMPARE "
                         f"layer={int(layer_id)} "
                         f"tokens={int(hidden_states.shape[0])} "
-                        f"ids_equal={bool(torch.equal(native_ids, injected_ids))} "
+                        f"native_id_shape={tuple(native_ids.shape)} "
+                        f"seam_id_shape={tuple(injected_ids.shape)} "
+                        f"ids_equal={ids_equal} "
                         f"id_mismatch_count={id_mismatch_count} "
-                        f"weights_equal={bool(torch.equal(native_weights, injected_weights))} "
-                        f"weight_max_abs={float(weight_diff.max().item())} "
-                        f"weight_mean_abs={float(weight_diff.mean().item())}",
+                        f"weights_equal={weights_equal} "
+                        f"weight_max_abs={weight_max_abs} "
+                        f"weight_mean_abs={weight_mean_abs}",
                         flush=True,
                     )
                     from vllm_moe_offload_ascend.moe_offload.router_parity import (
@@ -3643,6 +3843,44 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
                             topk_weights=native_weights,
                         )
                 return injected
+        # The pinned Ascend implementation materializes the shared rows for
+        # mix-placement but does not pass its own ``mix_placement`` arguments
+        # to select_experts().  Without these arguments the router emits only
+        # routed columns, silently omitting the always-active shared suffix.
+        # Keep this compatibility shim local to actual fused layers and leave
+        # a backend that starts forwarding the arguments unchanged.
+        if (
+            layer is not None
+            and bool(getattr(layer, "mix_placement", False))
+            and not bool(kwargs.get("mix_placement", False))
+        ):
+            try:
+                shared_count = int(getattr(layer, "n_shared_experts", 0) or 0)
+                routed_count = int(kwargs.get("num_experts", -1))
+            except (TypeError, ValueError):
+                shared_count = 0
+                routed_count = -1
+            if shared_count > 0:
+                if routed_count <= 0:
+                    raise RuntimeError(
+                        "mix-placement router requires a positive routed expert count; "
+                        f"layer={int(layer_id) if layer_id is not None else -1} "
+                        f"count={routed_count}"
+                    )
+                kwargs = dict(kwargs)
+                kwargs.update(
+                    mix_placement=True,
+                    num_logical_experts=routed_count,
+                    num_shared_experts=shared_count,
+                )
+                if not getattr(cls, "_latchmoe_mix_placement_router_announced", False):
+                    print(
+                        "LATCHMOE_BACKEND_COMPAT "
+                        "mix_placement_router_suffix=enabled",
+                        flush=True,
+                    )
+                    cls._latchmoe_mix_placement_router_announced = True
+
         topk_weights, topk_ids = original_select_experts(*args, **kwargs)
         if layer_id is not None:
             runtime = get_moe_offload_runtime()
@@ -3710,12 +3948,58 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
         if layer is None and args:
             layer = args[0]
         old_layer_id = getattr(layer_context, "layer_id", None)
+        old_layer = getattr(layer_context, "layer", None)
         if layer is not None:
+            layer_context.layer = layer
             lid = int(getattr(layer, "layer_id", -1))
             if lid >= 0:
                 layer_context.layer_id = lid
             # lid == -1: layer has no id; skip context so the seam does not
             # collide with other unidentified layers sharing key -1.
+
+        # During EngineCore's profile/dummy run, the upstream quant method can
+        # deliberately replace every top-k ID with a random routed ID to spread
+        # synthetic load. That transformation happens *after* select_experts.
+        # For a mix-placement seam it would overwrite the injected immutable
+        # shared suffix (for example [64, 65]) as well as the routed columns.
+        # Keep profile balancing on native paths, but never mutate a fused
+        # router result that the seam has already materialized and tied to a
+        # registered pinned lane.
+        if layer is not None and bool(kwargs.get("enable_force_load_balance", False)):
+            layer_id = int(getattr(layer, "layer_id", -1))
+            injected = (
+                moe_seam_inject.peek_injected_topk(layer_id)
+                if layer_id >= 0
+                else None
+            )
+            runtime = get_moe_offload_runtime()
+            layout_fn = getattr(runtime, "fused_shared_lane_layout", None)
+            fused_layout = (
+                layout_fn(layer_id)
+                if injected is not None and callable(layout_fn)
+                else None
+            )
+            if fused_layout is not None:
+                kwargs = dict(kwargs)
+                kwargs["enable_force_load_balance"] = False
+                record_event = getattr(runtime, "_record_profile_event", None)
+                if callable(record_event):
+                    injected_ids = injected[1]
+                    shape = getattr(injected_ids, "shape", ())
+                    record_event(
+                        "fused_shared_profile_router_preserved",
+                        layer_id=layer_id,
+                        start=perf_counter(),
+                        payload={
+                            "routed_expert_count": int(
+                                fused_layout.routed_expert_count
+                            ),
+                            "shared_expert_count": int(
+                                fused_layout.shared_expert_count
+                            ),
+                            "topk_width": int(shape[1]) if len(shape) >= 2 else -1,
+                        },
+                    )
         # Naive on-demand staging (no fixed slots): if this layer's experts were
         # offloaded to CPU at load time, stage them to device for this forward
         # and evict right after, so the plain grouped matmul sees device weights.
@@ -3731,6 +4015,10 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
                 delattr(layer_context, "layer_id")
             else:
                 layer_context.layer_id = old_layer_id
+            if old_layer is None and hasattr(layer_context, "layer"):
+                delattr(layer_context, "layer")
+            else:
+                layer_context.layer = old_layer
 
     cls.process_weights_after_loading = process_weights_after_loading
     cls.apply = apply

--- a/vllm_moe_offload_ascend/patches/patch_fused_moe.py
+++ b/vllm_moe_offload_ascend/patches/patch_fused_moe.py
@@ -1783,7 +1783,22 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             topk_ids=shared_ids,
             topk_weights=shared_weights,
         )
-        shared_result = original_fused_experts(self, shared_input)
+        # Ascend's AllGather dispatcher derives its ``active_num`` from the
+        # instance-level top_k rather than the input tensor width. The routed
+        # path keeps that value at the model's routed top-k, while this native
+        # call deliberately contains only the pinned shared suffix. Set it for
+        # this call only, then restore it before the next routed wave.
+        dispatcher = getattr(self, "token_dispatcher", None)
+        if dispatcher is None or not hasattr(dispatcher, "top_k"):
+            raise RuntimeError(
+                "fused shared B2 requires a token dispatcher with a mutable top_k"
+            )
+        original_dispatch_top_k = int(dispatcher.top_k)
+        dispatcher.top_k = shared_count
+        try:
+            shared_result = original_fused_experts(self, shared_input)
+        finally:
+            dispatcher.top_k = original_dispatch_top_k
         combined_out = routed_result.routed_out + shared_result.routed_out
         runtime._record_profile_event(
             "fused_shared_b2_once",

--- a/vllm_moe_offload_ascend/patches/patch_fused_moe.py
+++ b/vllm_moe_offload_ascend/patches/patch_fused_moe.py
@@ -1538,6 +1538,12 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
         if offload is None or not offload.enabled:
             return None
         runtime = get_moe_offload_runtime()
+        fused_layout_fn = getattr(runtime, "fused_shared_lane_layout", None)
+        fused_shared_layout = (
+            fused_layout_fn(int(offload.layer_id))
+            if callable(fused_layout_fn)
+            else None
+        )
         profile_adaptive_wave = _is_moe_offload_profile_run_active()
         graph_warmup_adaptive_wave = _is_moe_offload_graph_warmup_active()
         adaptive_wave_context = profile_adaptive_wave or graph_warmup_adaptive_wave
@@ -1613,6 +1619,16 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             token_count_ms = (perf_counter() - token_count_start) * 1000.0
         else:
             token_count_ms = 0.0
+        if fused_shared_layout is not None:
+            # The backend appends always-active shared IDs to every token's
+            # top-k. Capacity and B2 planning are routed-only: the shared suffix
+            # has fixed storage and is executed exactly once in a separate step.
+            routed_count = int(fused_shared_layout.routed_expert_count)
+            token_counts = {
+                int(expert_id): int(pair_count)
+                for expert_id, pair_count in token_counts.items()
+                if 0 <= int(expert_id) < routed_count
+            }
         active_experts = tuple(sorted(token_counts))
         active_expert_count = len(active_experts)
         b2_phase_match = runtime.should_use_b2_pair_waves(
@@ -1637,13 +1653,24 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
             "forward_phase": str(forward_phase),
             "profile_adaptive_wave": profile_adaptive_wave,
             "graph_warmup_adaptive_wave": graph_warmup_adaptive_wave,
+            # Cached offsets refer to the full routed+shared matrix. The
+            # routed B2 executor receives a narrower routed-only view, so
+            # rebuilding offsets is required to preserve pair positions.
             "pair_offsets_by_expert": (
-                route_stats.pair_offsets_by_expert
-                if route_stats is not None
-                else None
+                None
+                if fused_shared_layout is not None or route_stats is None
+                else route_stats.pair_offsets_by_expert
             ),
         }
         try:
+            if fused_shared_layout is not None:
+                return self._run_b2_fused_shared_once(
+                    fused_experts_input=fused_experts_input,
+                    before_dispatch_evt=before_dispatch_evt,
+                    token_counts=token_counts,
+                    shared_layout=fused_shared_layout,
+                    control_profile=control_profile,
+                )
             return self._run_b2_wave_prefill(
                 fused_experts_input=fused_experts_input,
                 active_experts=active_experts,
@@ -1670,6 +1697,108 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
                 fallback_reason=fallback_reason,
             )
 
+    def _run_b2_fused_shared_once(
+        self,
+        *,
+        fused_experts_input,
+        before_dispatch_evt,
+        token_counts,
+        shared_layout,
+        control_profile,
+    ):
+        """Run B2 for routed pairs and the fused shared suffix exactly once.
+
+        ``mix_placement`` flattens routed and shared pairs into one backend
+        input. Splitting that tensor naively would either count pinned shared
+        IDs against dynamic slot capacity or repeat them in every routed wave.
+        This method creates a routed-only B2 view and invokes the native fused
+        kernel once for the immutable shared suffix, then adds the two outputs.
+        """
+
+        runtime = get_moe_offload_runtime()
+        offload = fused_experts_input.offload
+        shared_count = int(shared_layout.shared_expert_count)
+        routed_count = int(shared_layout.routed_expert_count)
+        total_count = int(shared_layout.total_logical_expert_count)
+        topk_ids = fused_experts_input.topk_ids
+        topk_weights = fused_experts_input.topk_weights
+        if topk_ids.ndim != 2 or topk_weights.ndim != 2:
+            raise RuntimeError(
+                "fused shared B2 requires rank-2 top-k tensors; "
+                f"ids={tuple(topk_ids.shape)}, weights={tuple(topk_weights.shape)}"
+            )
+        if int(topk_ids.shape[1]) <= shared_count:
+            raise RuntimeError(
+                "fused shared B2 top-k has no routed columns after removing "
+                f"shared suffix: topk={int(topk_ids.shape[1])}, shared={shared_count}"
+            )
+
+        shared_ids = topk_ids[:, -shared_count:]
+        shared_weights = topk_weights[:, -shared_count:]
+        expected_shared_ids = torch.arange(
+            routed_count,
+            total_count,
+            dtype=shared_ids.dtype,
+            device=shared_ids.device,
+        ).view(1, shared_count).expand_as(shared_ids)
+        if not bool(torch.equal(shared_ids, expected_shared_ids)):
+            raise RuntimeError(
+                "fused shared B2 expected appended pinned shared IDs "
+                f"[{routed_count}, {total_count}), but router suffix differs"
+            )
+
+        routed_input = replace(
+            fused_experts_input,
+            topk_ids=topk_ids[:, :-shared_count],
+            topk_weights=topk_weights[:, :-shared_count],
+        )
+        routed_profile = dict(control_profile)
+        routed_profile["pair_offsets_by_expert"] = None
+        routed_result = self._run_b2_wave_prefill(
+            fused_experts_input=routed_input,
+            active_experts=tuple(sorted(int(expert_id) for expert_id in token_counts)),
+            token_counts=token_counts,
+            before_dispatch_evt=before_dispatch_evt,
+            control_profile=routed_profile,
+        )
+        if routed_result is None:
+            raise RuntimeError("fused shared B2 routed executor produced no result")
+
+        pinned_weights = runtime.capture_safe_slot_weights(
+            layer_id=int(offload.layer_id)
+        )
+        if pinned_weights is None:
+            raise RuntimeError(
+                "fused shared B2 requires the registered pinned shared lane; "
+                f"layer={int(offload.layer_id)}"
+            )
+        pinned_weights.validate_backend_ready(
+            expected_device_type=offload.expected_device_type
+        )
+        shared_input = replace(
+            self._with_prepared_slot_weights(
+                fused_experts_input,
+                pinned_weights,
+            ),
+            topk_ids=shared_ids,
+            topk_weights=shared_weights,
+        )
+        shared_result = original_fused_experts(self, shared_input)
+        combined_out = routed_result.routed_out + shared_result.routed_out
+        runtime._record_profile_event(
+            "fused_shared_b2_once",
+            layer_id=int(offload.layer_id),
+            start=perf_counter(),
+            payload={
+                "routed_expert_count": routed_count,
+                "pinned_shared_expert_count": shared_count,
+                "shared_pairs": int(shared_ids.numel()),
+                "shared_pair_execution_count": 1,
+                "routed_pairs": int(routed_input.topk_ids.numel()),
+            },
+        )
+        return replace(routed_result, routed_out=combined_out)
+
     def _run_b2_wave_prefill(
         self,
         *,
@@ -1690,6 +1819,10 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
 
         runtime = get_moe_offload_runtime()
         offload = fused_experts_input.offload
+        routed_expert_count = runtime.routed_expert_count_for_layer(
+            layer_id=int(offload.layer_id),
+            fallback=int(offload.num_logical_experts),
+        )
         num_slots = int(runtime.config.num_slots)
         device = fused_experts_input.topk_ids.device
         b2_total_start = (
@@ -1871,7 +2004,7 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
                 wave_microbatch_plans = build_b2_device_wave_microbatch_plans(
                     fused_experts_input.topk_ids,
                     waves,
-                    num_logical_experts=int(offload.num_logical_experts),
+                    num_logical_experts=routed_expert_count,
                     active_experts=unique_active,
                     physical_slot_by_expert={},
                     wave_pair_counts=tuple(
@@ -3223,6 +3356,7 @@ def _patch_moe_comm_method_runtime_hooks(_comm: Any) -> None:
     cls._with_prepared_slot_weights = _with_prepared_slot_weights
     cls._maybe_apply_moe_offload_plan = _maybe_apply_moe_offload_plan
     cls._maybe_run_b2_wave_prefill = _maybe_run_b2_wave_prefill
+    cls._run_b2_fused_shared_once = _run_b2_fused_shared_once
     cls._run_b2_wave_prefill = _run_b2_wave_prefill
     cls._run_b2_full_layer_reference = _run_b2_full_layer_reference
     cls._run_b2_pair_wave = _run_b2_pair_wave
@@ -3545,10 +3679,14 @@ def _patch_unquantized_moe_method(_fused_moe: Any) -> None:
             and registered
         ):
             buf = runtime.log2phy_buffer(layer_id)
-            num_logical_experts = (
+            total_logical_experts = (
                 int(buf.numel()) if buf is not None else int(getattr(layer, "w13_weight").shape[0])
             )
-            if runtime.is_static_residency_regime(num_logical_experts):
+            routed_expert_count = runtime.routed_expert_count_for_layer(
+                layer_id=layer_id,
+                fallback=total_logical_experts,
+            )
+            if runtime.is_static_residency_regime(routed_expert_count):
                 runtime.stage_full_residency_slot_plan(layer_id=layer_id)
         return result
 
@@ -3921,13 +4059,57 @@ def _patch_ascend_moe_runner(_fused_moe: Any) -> None:
             support = CapabilitySupport(state="unsupported", blockers=tuple(extra_blockers))
         self._seam_capability = descriptor
         self._seam_capability_support = support
-        if not support.enabled:
-            return False
-        self._seam_num_logical_experts = descriptor.routed_expert_count
         from vllm_moe_offload_ascend.moe_offload.runtime import (
             get_moe_offload_runtime,
         )
         runtime = get_moe_offload_runtime()
+        if descriptor.shared_mode == "fused_mix_placement":
+            # A fused router emits appended shared IDs in the same top-k tensor
+            # as routed IDs. The seam must not proceed until the runtime has
+            # registered the corresponding immutable physical suffix; otherwise
+            # a later stage call could treat shared IDs as evictable routed rows.
+            layout_fn = getattr(runtime, "fused_shared_lane_layout", None)
+            layout = (
+                layout_fn(self._seam_layer_id)
+                if callable(layout_fn)
+                else None
+            )
+            expected_pinned_ids = tuple(
+                range(
+                    int(descriptor.routed_expert_count),
+                    int(descriptor.routed_expert_count)
+                    + int(descriptor.shared_expert_count),
+                )
+            )
+            try:
+                layout_matches = (
+                    layout is not None
+                    and int(layout.routed_expert_count)
+                    == int(descriptor.routed_expert_count)
+                    and int(layout.shared_expert_count)
+                    == int(descriptor.shared_expert_count)
+                    and int(layout.total_logical_expert_count)
+                    == int(descriptor.routed_expert_count)
+                    + int(descriptor.shared_expert_count)
+                    and tuple(int(expert_id) for expert_id in layout.pinned_logical_ids)
+                    == expected_pinned_ids
+                )
+            except (AttributeError, TypeError, ValueError):
+                layout_matches = False
+            if not layout_matches:
+                blocker = (
+                    "fused_shared_lane_unregistered"
+                    if layout is None
+                    else "fused_shared_lane_layout_mismatch"
+                )
+                support = CapabilitySupport(
+                    state="unsupported",
+                    blockers=tuple((*support.blockers, blocker)),
+                )
+                self._seam_capability_support = support
+        if not support.enabled:
+            return False
+        self._seam_num_logical_experts = descriptor.routed_expert_count
         if descriptor.shared_mode == "external_resident":
             shared_experts = getattr(self, "_shared_experts", None)
             shared_gate = getattr(self, "shared_expert_gate", None)


### PR DESCRIPTION
## 变更\n\n- 为 Ascend fused/mix-placement shared experts 固定追加的 shared lane，避免 profile force-load-balance 覆盖 shared ID。\n- 使 router 诊断与实际 6 routed + 2 shared ABI 对齐，并在 shape 不匹配时安全记录。\n- 在 B2 routed/shared 分拆执行时正确收窄并恢复 dispatcher top-k。\n- 增加 Ascend mix-placement 构造兼容和 focused host 回归。\n\n## 验证\n\n- host：84 passed\n- DeepSeek-V2-Lite，NPU 5，mix_placement=true：完整资格 bundle verifier passed\n- 11 个门禁全绿：router/layer/token exactness、PIECEWISE capture/replay、4-slot overflow、decode churn、H2D lease/release、zero eager fallback\n- router 和 layer-boundary 各 104 条记录均为零差异\n- fixed shared IDs [64, 65] 在 eager、graph、overflow 三条路径均通过\n\n资格 artifact：\n/workspace/latchmoe-issue25-npu5/deepseek-v2-lite-fused-qualification-r3-profile-suffix-preserved/\n\nCloses #25