### PR TITLE
feat: standardize LatchMoE Extension Manager integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ paper/PAPER_CLAIM_AUDIT.md
 paper/PAPER_IMPROVEMENT_LOG.md
 paper/PROOF_AUDIT.json
 paper/PROOF_AUDIT.md
+.venv/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ does not alias plugin modules into the `vllm_ascend.*` namespace. The target
 model, OpenAI-compatible API, and scheduler semantics are untouched;
 uninstalling the plugin restores stock behavior.
 
+LatchMoE also publishes a static Extension Manager manifest under the
+project-owned `vllm_hust.extension_bundles` namespace. Discovery reads package
+metadata only and does not import or activate the runtime. The Manager records
+LatchMoE as a trusted in-process vLLM-Ascend worker extension; vLLM remains the
+lifecycle owner and the `latchmoe` launcher remains responsible for the strict
+environment check and for rejecting prefix caching.
+
+```bash
+pip install vllm-hust-ext vllm-moe-offload-ascend
+vllm-hust-ext extension check org.vllm-hust.latchmoe
+vllm-hust-ext extension enable org.vllm-hust.latchmoe
+vllm-hust-ext run -- latchmoe serve /path/to/model
+```
+
+The check must be supplied with evidence for MoE offload seam ABI 1. A matching
+vLLM version alone does not prove that the required vLLM-Ascend seam is present.
+
 ---
 
 ## Qualified Graph Result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,15 @@ latchmoe = "vllm_moe_offload_ascend.launcher:main"
 [project.entry-points."vllm.general_plugins"]
 moe_offload_ascend = "vllm_moe_offload_ascend:register"
 
+[project.entry-points."vllm_hust.extension_bundles"]
+"org.vllm-hust.latchmoe" = "vllm_moe_offload_ascend"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["vllm_moe_offload_ascend*"]
 
 [tool.setuptools.package-data]
-vllm_moe_offload_ascend = ["compatibility.lock"]
+vllm_moe_offload_ascend = [
+    "compatibility.lock",
+    "vllm-hust-extension-v0.2.json",
+]

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -1,29 +1,60 @@
 from __future__ import annotations
 
 import json
+from importlib import resources
 from pathlib import Path
+
+import tomllib
 
 import vllm_moe_offload_ascend as plugin
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_general_plugin_entry_point_is_declared() -> None:
     config = (REPO_ROOT / "pyproject.toml").read_text()
 
-    assert '[project.scripts]' in config
+    assert "[project.scripts]" in config
     assert 'latchmoe = "vllm_moe_offload_ascend.launcher:main"' in config
     assert '[project.entry-points."vllm.general_plugins"]' in config
     assert '[project.entry-points."vllm.platform_plugins"]' not in config
-    assert (
-        'moe_offload_ascend = "vllm_moe_offload_ascend:register"' in config
+    assert 'moe_offload_ascend = "vllm_moe_offload_ascend:register"' in config
+
+
+def test_extension_manager_registration_is_static_and_project_owned() -> None:
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+    registrations = config["project"]["entry-points"]["vllm_hust.extension_bundles"]
+    assert registrations == {"org.vllm-hust.latchmoe": "vllm_moe_offload_ascend"}
+
+
+def test_extension_manager_manifest_preserves_runtime_boundary() -> None:
+    path = resources.files("vllm_moe_offload_ascend").joinpath(
+        "vllm-hust-extension-v0.2.json"
     )
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+
+    assert manifest["schema_version"] == "0.2-experimental"
+    assert manifest["extension_id"] == "org.vllm-hust.latchmoe"
+    assert manifest["kind"] == "in_process_plugin"
+    assert manifest["host"] == {
+        "provider": "vllm",
+        "name": "vllm",
+        "version_range": "==0.21.0",
+    }
+    assert manifest["runtime"]["process_scope"] == "vllm-ascend-worker"
+    assert manifest["lifecycle_owner"] == "vllm"
+    assert manifest["requires_services"] == []
+    assert manifest["protocols"] == [
+        {
+            "name": "vllm.ascend.moe-offload-seam",
+            "version_range": ">=1,<2",
+        }
+    ]
 
 
 def test_vllm_hust_optimization_manifest_matches_entry_point() -> None:
-    manifest = json.loads(
-        (REPO_ROOT / ".vllm-hust" / "optimization.json").read_text()
-    )
+    manifest = json.loads((REPO_ROOT / ".vllm-hust" / "optimization.json").read_text())
 
     assert manifest["schema_version"] == 1
     assert manifest["id"] == "latchmoe"

--- a/vllm_moe_offload_ascend/vllm-hust-extension-v0.2.json
+++ b/vllm_moe_offload_ascend/vllm-hust-extension-v0.2.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "0.2-experimental",
+  "extension_id": "org.vllm-hust.latchmoe",
+  "extension_version": "0.1.0",
+  "kind": "in_process_plugin",
+  "host": {
+    "provider": "vllm",
+    "name": "vllm",
+    "version_range": "==0.21.0"
+  },
+  "runtime": {
+    "type": "python",
+    "process_scope": "vllm-ascend-worker",
+    "isolation": "trusted_in_process"
+  },
+  "lifecycle_owner": "vllm",
+  "protocols": [
+    {
+      "name": "vllm.ascend.moe-offload-seam",
+      "version_range": ">=1,<2"
+    }
+  ],
+  "implementation": [
+    {
+      "type": "python_entry_point",
+      "group": "vllm.general_plugins",
+      "name": "moe_offload_ascend"
+    }
+  ],
+  "requires_services": [],
+  "components": [
+    {
+      "component_id": "moe-offload-runtime",
+      "contracts": [
+        "vllm.ascend.moe-offload.v1"
+      ],
+      "execution_planes": [
+        "worker",
+        "device"
+      ],
+      "isolation": "trusted_in_process",
+      "implementation_ref": "vllm_moe_offload_ascend:register",
+      "permissions": [
+        "device_access",
+        "filesystem_read",
+        "filesystem_write"
+      ]
+    }
+  ],
+  "activation": {
+    "entry_points": [
+      {
+        "group": "vllm.general_plugins",
+        "name": "moe_offload_ascend"
+      }
+    ],
+    "environment": {
+      "VLLM_ASCEND_MOE_OFFLOAD_GB": "14",
+      "VLLM_ASCEND_MOE_OFFLOAD_SEW_DATAPLANE": "1",
+      "VLLM_ASCEND_MOE_OFFLOAD_MAX_NUM_SEQS_HINT": "1"
+    },
+    "additional_config": {}
+  }
+}


### PR DESCRIPTION
## Summary
- register a static manifest under the project-owned llm_hust.extension_bundles namespace
- classify LatchMoE as a trusted in-process vLLM-Ascend worker extension
- pin the verified vLLM 0.21.0 host range and require explicit MoE seam ABI 1 evidence
- preserve vLLM lifecycle ownership and the strict latchmoe launcher boundary
- document install, check, enable, run, and rollback behavior

## Validation
- manifest parsed with current Extension Manager 0.2 parser
- editable static discovery succeeded without implementation import
- 6 plugin-contract tests passed
- wheel and sdist built; wheel contains manifest and both entry-point groups
- Ruff and diff checks passed

## Explicit limitations
This does not broaden runtime support: prefix caching, quantized weights, and multi-NPU execution remain unsupported/fail-closed.