### PR TITLE
docs: separate LatchMoE compatibility from effectiveness

### DIFF
--- a/.vllm-hust/optimization.json
+++ b/.vllm-hust/optimization.json
@@ -26,7 +26,14 @@
         "model": "Qwen3-30B-A3B",
         "tensor_parallel_size": 4,
         "execution_mode": "graph",
-        "status": "compatible_functional_performance_degraded",
+        "status": "compatible",
+        "functional_compatibility": "passed",
+        "effectiveness_qualification": {
+          "status": "not-beneficial-in-tested-cell",
+          "scope": "Qwen3-30B-A3B / BF16 / TP4 PIECEWISE graph / qualified offload configuration",
+          "reason": "Functional gates passed, but measured throughput was lower than the no-plugin baseline in this exact cell"
+        },
+        "runtime_state_source": "live_instance_observation_only",
         "evidence": "docs/evidence/sage-mate-20260904-tp4-graph.md"
       },
       {

--- a/docs/evidence/sage-mate-20260904-tp4-graph.md
+++ b/docs/evidence/sage-mate-20260904-tp4-graph.md
@@ -53,7 +53,8 @@ For ten requests, LatchMoE measured TTFT p50/p95 3.678/7.730 seconds,
 end-to-end latency p50/p95 25.941/31.808 seconds, and output throughput
 p50/p95 2.907/3.010 tok/s. The matched no-plugin baseline output throughput
 was about 23.57 tok/s. This lane is therefore labelled
-`compatible_functional_performance_degraded` and must not be advertised as a
+functionally `compatible`; effectiveness is `not-beneficial-in-tested-cell` for
+this exact measured configuration and must not be advertised as a
 speedup.
 
 ## Evidence custody

--- a/tests/test_plugin_contract.py
+++ b/tests/test_plugin_contract.py
@@ -73,6 +73,15 @@ def test_vllm_hust_optimization_manifest_matches_entry_point() -> None:
         "--tensor-parallel-size",
         "4",
     ]
+    moe, dense = manifest["compatibility"]["model_qualifications"]
+    assert moe["status"] == "compatible"
+    assert moe["functional_compatibility"] == "passed"
+    assert moe["effectiveness_qualification"]["status"] == (
+        "not-beneficial-in-tested-cell"
+    )
+    assert moe["runtime_state_source"] == "live_instance_observation_only"
+    assert dense["model"] == "Qwen3.8-27B"
+    assert dense["status"] == "not_applicable"
 
 
 def test_register_retries_idempotent_patch_path(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- keep dense Qwen3.8-27B explicitly Not Applicable
- record Qwen3-30B-A3B TP4 graph functional compatibility independently from effectiveness
- classify only the measured offload cell as not-beneficial-in-tested-cell
- keep live runtime state separate

## Validation
- exact qualification image, no NPU assigned: `python3 -m pytest -q tests/test_plugin_contract.py` (6 passed)
- existing NPU0-3 evidence: four-rank expert seams, 388 graph replays, 48/48 graph-address checks, host/device swap, concurrency/cancel/recovery